### PR TITLE
AQC-103: CODEOWNERS + PR risk checklist for trading-critical changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# Risk-critical paths — require @fol2 review.
+#
+# GitHub enforces these rules on protected branches.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# --- Order execution & risk ---
+/engine/oms.py                    @fol2
+/engine/oms_reconciler.py         @fol2
+/live/                            @fol2
+/exchange/                        @fol2
+
+# --- Kill-switch & risk modules (current + future) ---
+/engine/kill_switch*              @fol2
+/engine/risk*                     @fol2
+
+# --- Production config ---
+/config/strategy_overrides.yaml   @fol2
+
+# --- Governance docs (changing guardrails = risk decision) ---
+/docs/success_metrics.md          @fol2
+/docs/strategy_lifecycle.md       @fol2

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+<!-- 1-3 bullet points describing the change -->
+
+## Risk checklist
+
+> Complete this section for **every** PR. If any box is checked, `@fol2` review is required before merge.
+
+- [ ] This PR modifies **kill-switch or risk-limit** logic (`engine/kill_switch*`, `engine/risk*`, `docs/success_metrics.md`)
+- [ ] This PR modifies **order sizing, leverage, or margin** logic (`engine/oms.py`, `engine/oms_reconciler.py`)
+- [ ] This PR modifies **live order execution** code (`live/`, `exchange/`)
+- [ ] This PR modifies **production config** (`config/strategy_overrides.yaml`)
+- [ ] This PR modifies the **strategy lifecycle or promotion gates** (`docs/strategy_lifecycle.md`)
+
+### If any box above is checked:
+
+- [ ] Backtest replay run confirms no regression (attach summary or link)
+- [ ] Paper trading verified (or not applicable — explain why)
+- [ ] No kill-switch or guardrail thresholds were weakened without explicit sign-off
+
+## Test plan
+<!-- How was this tested? -->


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` requiring `@fol2` review on risk-critical paths (OMS, live execution, exchange, kill-switch, production config, governance docs)
- Add `.github/pull_request_template.md` with mandatory risk checklist for changes touching sizing, leverage, kill-switches, or promotion gates

Closes #5

## Test plan
- [ ] Verify CODEOWNERS paths match actual repo structure
- [ ] Confirm PR template renders correctly on next PR creation
- [ ] Enable branch protection rule requiring CODEOWNERS review (manual step post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)