### PR TITLE
Docs: add strategy factory planning notes

### DIFF
--- a/plan/1/scrum-backlog.md
+++ b/plan/1/scrum-backlog.md
@@ -1,0 +1,746 @@
+Below is a Scrum-ready backlog with epics and detailed tickets that implement the full "strategy factory" workflow you described (GPU generates candidates → CPU validates under stress/out‑of‑sample → controlled deployment → live monitoring + kill switches → rotation). I've written this in a way you can paste into Jira/Linear with minimal editing.
+
+I'm assuming your repo structure and tooling from the report: Rust `mei-backtester` (GPU sweep + CPU replay), SQLite candle DBs + funding DB, `generate_config.py`, `deploy_sweep.py`, sidecar ingestion, hot-reloadable `strategy_overrides.yaml`, and you're trading Hyperliquid perps.
+
+I'm also assuming the product goal is: "Operate a repeatable, automated system that deploys short-lived edges while enforcing strict downside controls," not "find one config forever."
+
+Naming convention suggestion:
+
+* Epics: AQC-E### (AI Quant Crypto)
+* Tickets: AQC-### (stories/tasks)
+* Priority: P0 (must), P1 (should), P2 (nice)
+* Complexity: 1,2,3,5,8,13 (story points; no time estimates)
+* Labels: `data`, `backtester`, `gpu`, `validation`, `engine`, `risk`, `ops`, `observability`
+
+Definition of Done (global, apply to all tickets):
+
+* Code merged to main with tests (where applicable)
+* Repro steps documented (README/runbook updated)
+* Artifacts/logging present so behaviour is auditable
+* Safe failure modes (no "silently proceeds" in trading-critical paths)
+
+---
+
+EPIC AQC-E100: Product framing, governance, and "what success means"
+Goal: make sure the team is optimising for live survivability and repeatability, not backtest vanity.
+
+AQC-101 (P0, 3) Define success metrics + guardrails for the system
+Description: Document a short list of operational metrics and risk limits that define "working."
+Acceptance criteria:
+
+* A one-page doc in repo (e.g., `docs/success_metrics.md`) specifying:
+
+  * Live max daily loss limit, max equity drawdown, max leverage exposure guidelines
+  * Minimum trade count thresholds for evaluation windows
+  * Promotion criteria (paper → live)
+  * Rotation criteria (when to retire a config)
+    Dependencies: none.
+    Parallel: yes (independent).
+
+AQC-102 (P0, 2) Create a strategy lifecycle state machine spec
+Description: Define states: `candidate → validated → paper → live_small → live_full → paused → retired`.
+Acceptance criteria:
+
+* State diagram + transitions + triggers written and reviewed
+* Each trigger is measurable from logs/metrics (no subjective triggers)
+  Dependencies: AQC-101.
+  Parallel: yes.
+
+AQC-103 (P1, 3) Establish coding + review rules for trading-critical changes
+Description: Require review from "risk owner" on kill-switch, sizing, order logic changes.
+Acceptance criteria:
+
+* CODEOWNERS or equivalent enforced
+* Checklist added to PR template for risk-impacting changes
+  Dependencies: none.
+  Parallel: yes.
+
+AQC-104 (P1, 5) Build a "runbook" skeleton for ops and incident handling
+Description: When the bot misbehaves, what do we do?
+Acceptance criteria:
+
+* `docs/runbook.md` includes: pause trading, roll back config, verify DB, rerun validation, restart services
+  Dependencies: none.
+  Parallel: yes.
+
+---
+
+EPIC AQC-E200: Data foundation (candles + funding) and longer history
+Goal: stop flying blind with only 12–19 days of 3m/5m data; ensure integrity and continuity.
+
+AQC-201 (P0, 5) Data freshness + gap detection job for all candle DBs
+Description: Add a script that checks per-interval/per-symbol last timestamp, missing ranges, and bar counts.
+Acceptance criteria:
+
+* Script outputs JSON + human summary
+* Non-zero exit code if gaps exceed threshold
+* Emits "OK"/"WARN"/"FAIL" status per DB
+  Dependencies: none.
+  Parallel: yes.
+
+AQC-202 (P0, 3) Funding DB freshness verification + anomaly checks
+Description: Check latest funding timestamp, missing hours, outliers.
+Acceptance criteria:
+
+* Script flags missing ranges and suspicious spikes
+* Produces machine-readable output for pipeline gating
+  Dependencies: none.
+  Parallel: yes.
+
+AQC-203 (P0, 8) Modify sidecar/ingestion to retain append-only history beyond 5000 bars
+Description: Current "HL retains 5000 bars" shouldn't cap your stored history. Ensure you append new bars and never truncate (or archive old partitions).
+Acceptance criteria:
+
+* 3m and 5m DBs grow beyond 5000 bars per symbol
+* No duplicates (unique constraint on `(symbol, time)` or equivalent)
+* Documented migration steps (schema changes if needed)
+  Dependencies: AQC-201.
+  Parallel: mostly yes (can start now).
+
+AQC-204 (P1, 5) Implement DB partitioning/archival strategy for large history
+Description: Avoid gigantic single SQLite files and improve query speed. Options: monthly partition DBs or maintain indices.
+Acceptance criteria:
+
+* Chosen approach documented
+* Queries used by backtester remain fast
+* Auto-scope and loaders work across partitions (or a unified view)
+  Dependencies: AQC-203.
+  Parallel: yes.
+
+AQC-205 (P1, 3) Add "universe change" tracking to reduce survivorship bias
+Description: Track when symbols appear/disappear in HL universe and store metadata.
+Acceptance criteria:
+
+* A table (or file) recording symbol listing/delisting dates
+* Backtests can optionally filter to symbols active during the tested period
+  Dependencies: AQC-203 (recommended).
+  Parallel: yes.
+
+AQC-206 (P2, 8) Add optional orderbook snapshot storage for later slippage modelling
+Description: Store occasional BBO/OB snapshots for empirical slippage study.
+Acceptance criteria:
+
+* Configurable sampling rate
+* Storage bounded (rotation)
+  Dependencies: none.
+  Parallel: yes.
+
+---
+
+EPIC AQC-E300: Backtester + replay enhancements (truth engine improvements)
+Goal: make CPU replay a first-class validator (time slicing, richer metrics, friction tests).
+
+AQC-301 (P0, 8) Add explicit time-range flags to `replay` (and optionally `sweep`)
+Description: Add CLI args: `--start-ts` and `--end-ts` (ISO8601 or epoch) to force evaluation on a subrange. Must cooperate with auto-scope.
+Acceptance criteria:
+
+* `replay` can run on a specified subrange within DB coverage
+* Output prints the final effective range used
+* If requested range is invalid/outside coverage, fails loudly
+  Dependencies: none.
+  Parallel: yes (core enabler for walk-forward).
+
+AQC-302 (P0, 5) Extend replay JSON output with per-symbol stats
+Description: Add `per_symbol` results: PnL, trades, win rate, max DD, fees/slippage impact.
+Acceptance criteria:
+
+* JSON output includes per-symbol breakdown
+* `total_*` fields remain unchanged
+  Dependencies: none.
+  Parallel: yes.
+
+AQC-303 (P0, 5) Add a replay option for slippage override without config edits
+Description: Support `--slippage-bps` CLI override (and record it in output).
+Acceptance criteria:
+
+* Slippage can be set per replay run
+* Output includes `slippage_bps`
+  Dependencies: none.
+  Parallel: yes.
+
+AQC-304 (P1, 8) Add trade-level CSV export for analysis
+Description: Optional `--export-trades path.csv` containing time, symbol, side, entry/exit, pnl, MAE/MFE, reason codes.
+Acceptance criteria:
+
+* CSV export works deterministically
+* Includes unique trade IDs
+  Dependencies: AQC-301 recommended.
+  Parallel: yes.
+
+AQC-305 (P1, 5) Standardize "reason codes" for exits/entries in CPU engine
+Description: Useful for debugging why configs degrade live.
+Acceptance criteria:
+
+* Enumerated reason codes (stop, tp, trail, filter_exit, funding_exit, etc.)
+* Included in JSON and trade CSV export
+  Dependencies: AQC-304 (or vice versa).
+  Parallel: yes.
+
+AQC-306 (P1, 13) GPU/CPU parity test harness (unit + integration)
+Description: For a small fixed dataset and fixed config, compare GPU sweep result to CPU replay (within tolerances).
+Acceptance criteria:
+
+* Automated test that runs in CI (CPU-only) with small fixture dataset
+* Documents known divergence causes, sets guardrails
+  Dependencies: AQC-302 recommended.
+  Parallel: yes (but heavier).
+
+AQC-307 (P2, 13) Optional: improve GPU kernel realism (sub-bar exits / f64 accumulation)
+Description: Big-ticket parity work. Only do if needed after pipeline is stable.
+Acceptance criteria:
+
+* Defined measurable reduction in GPU/CPU divergence
+  Dependencies: AQC-306.
+  Parallel: later.
+
+---
+
+EPIC AQC-E400: Strategy factory orchestrator (nightly pipeline end-to-end)
+Goal: one command produces sweeps → configs → validations → ranked shortlist → paper deploy candidate.
+
+AQC-401 (P0, 8) Create `factory_run.py` orchestrator (single entrypoint)
+Description: A script that runs the entire workflow with a run_id and stores artifacts.
+Acceptance criteria:
+
+* `python3 factory_run.py --run-id ...` runs:
+
+  * data checks (AQC-E200 outputs)
+  * GPU sweeps (selected combos)
+  * config generation (top N)
+  * CPU validations (suite)
+  * final ranked report + recommended config(s)
+* Produces an artifacts directory keyed by run_id
+  Dependencies: AQC-201, AQC-202, AQC-301, AQC-303.
+  Parallel: can start now with stubs.
+
+AQC-402 (P0, 5) Sweep runner module with guardrails (only "safe" combos)
+Description: Encode your discovered constraint: GPU sweep only used for ≤19d windows unless explicitly overridden.
+Acceptance criteria:
+
+* Default allowed combos: (30m/5m, 1h/5m, 30m/3m, 1h/3m)
+* Requires an explicit flag to run 15m+ / 30m+ sub-bars
+* Logs the auto-scoped period length each run
+  Dependencies: AQC-401.
+  Parallel: yes.
+
+AQC-403 (P0, 5) Config shortlist generator (top by DD + balanced)
+Description: Automate `generate_config.py` across multiple sort modes and ranks.
+Acceptance criteria:
+
+* Generates e.g. top 10 DD + top 10 balanced per sweep output
+* Deduplicates configs by hash (avoid minor float noise duplicates)
+  Dependencies: AQC-401.
+  Parallel: yes.
+
+AQC-404 (P1, 5) Add "repro metadata" capture for every run
+Description: Record git commit, binary versions, CUDA/driver info, seeds, CLI args.
+Acceptance criteria:
+
+* `run_metadata.json` stored per run_id
+* Every produced config references originating sweep and validation outputs
+  Dependencies: AQC-401.
+  Parallel: yes.
+
+AQC-405 (P1, 3) Add pipeline resume/retry support
+Description: If a run crashes halfway, resume from artifacts.
+Acceptance criteria:
+
+* Steps are idempotent
+* `--resume` skips completed stages
+  Dependencies: AQC-401.
+  Parallel: yes.
+
+AQC-406 (P1, 3) Add "smoke mode" for fast daily runs
+Description: Lower trials + fewer candidates for weekdays.
+Acceptance criteria:
+
+* `--profile smoke|daily|deep` controls trials and candidate counts
+  Dependencies: AQC-401.
+  Parallel: yes.
+
+AQC-407 (P2, 5) Add compute resource throttles / scheduling safety
+Description: Avoid Windows TDR issues and avoid trading-engine interference.
+Acceptance criteria:
+
+* Orchestrator checks GPU availability and can defer/exit if engine is running GPU tasks
+  Dependencies: AQC-401.
+  Parallel: later.
+
+---
+
+EPIC AQC-E500: Validation suite (walk-forward, stress, robustness scoring)
+Goal: stop deploying "lucky" configs. Make selection data-driven with out-of-sample pressure.
+
+AQC-501 (P0, 8) Implement walk-forward validation runner
+Description: Given a config and a date range, run multiple train/test splits. (Even if you don't "train" in replay, you can treat the sweep window as train and separate test windows.)
+Acceptance criteria:
+
+* Defines a configurable set of splits for 12–19 day windows
+* Produces per-split metrics and aggregated score
+  Dependencies: AQC-301.
+  Parallel: yes.
+
+AQC-502 (P0, 5) Add slippage stress matrix (10/20/30 bps)
+Description: For each candidate, run CPU replay under 3 friction levels and compute degradation.
+Acceptance criteria:
+
+* Outputs a "slippage fragility" metric
+* Reject configs that flip sign at 20 bps (configurable)
+  Dependencies: AQC-303, AQC-401.
+  Parallel: yes.
+
+AQC-503 (P0, 5) Add concentration / diversification checks
+Description: Use per-symbol breakdown (AQC-302) to compute concentration metrics.
+Acceptance criteria:
+
+* Compute: %PnL top1 symbol, top5 symbols, number of symbols traded, long/short contribution
+* Threshold-based rejection rules in config
+  Dependencies: AQC-302.
+  Parallel: yes.
+
+AQC-504 (P0, 5) Define and implement a single "stability score" ranking formula
+Description: One scalar score to rank candidates, prioritizing robust OOS + low DD + low fragility.
+Acceptance criteria:
+
+* Score formula versioned (`score_v1`)
+* Report shows components + final score
+  Dependencies: AQC-501, AQC-502, AQC-503.
+  Parallel: yes (can draft formula earlier).
+
+AQC-505 (P1, 8) Add "parameter sensitivity" sanity check
+Description: Take top config and perturb key axes slightly (e.g., ±1 on EMA windows, ±0.1 ATR multipliers) to see if edge vanishes.
+Acceptance criteria:
+
+* Automated perturbation set
+* Produces a "sensitivity" metric
+  Dependencies: AQC-401, AQC-301.
+  Parallel: yes.
+
+AQC-506 (P1, 8) Add Monte Carlo / bootstrap on trade outcomes (optional)
+Description: Shuffle trade sequence or resample to estimate distribution of DD and returns.
+Acceptance criteria:
+
+* Produces confidence intervals for DD and return
+  Dependencies: AQC-304 recommended.
+  Parallel: yes.
+
+AQC-507 (P1, 5) Create reject-reason reporting ("why this config was rejected")
+Description: For each candidate, output human-readable reasons (e.g., "fails 20 bps stress," "too concentrated," "OOS negative").
+Acceptance criteria:
+
+* `validation_report.md` includes reasons per candidate
+  Dependencies: AQC-401, AQC-504.
+  Parallel: yes.
+
+AQC-508 (P2, 8) Add "cross-universe" validation (subset of symbols)
+Description: Validate on top-liquidity subset vs full universe to see if edge depends on illiquid tails.
+Acceptance criteria:
+
+* Configurable symbol sets
+* Report comparison
+  Dependencies: AQC-302.
+  Parallel: later.
+
+---
+
+EPIC AQC-E600: Strategy registry, artifact storage, and reproducibility
+Goal: every live deployment is traceable to a run_id, a sweep file, and a validation report.
+
+AQC-601 (P0, 5) Create standardized artifacts directory layout
+Description: Example: `artifacts/YYYY-MM-DD/run_<id>/` with subfolders for sweeps/configs/replays/reports/logs.
+Acceptance criteria:
+
+* Orchestrator writes to this layout
+* README explains structure
+  Dependencies: AQC-401.
+  Parallel: yes.
+
+AQC-602 (P0, 5) Implement config hashing + immutable IDs
+Description: Hash the fully materialized YAML (normalized) and treat it as immutable ID.
+Acceptance criteria:
+
+* `config_id` = sha256 of normalized YAML
+* Stored in reports and deployment metadata
+  Dependencies: AQC-601.
+  Parallel: yes.
+
+AQC-603 (P0, 5) Build a local "registry index" (SQLite or JSONL)
+Description: Index all configs and runs: metrics, dates, verdict, deployed yes/no, retirement reason.
+Acceptance criteria:
+
+* Queryable by run_id, config_id, date
+* Used by deployment and reporting
+  Dependencies: AQC-601, AQC-602.
+  Parallel: yes.
+
+AQC-604 (P1, 3) Add artifact retention policy + pruning
+Description: Keep deep artifacts N days, keep summaries forever.
+Acceptance criteria:
+
+* Configurable retention settings
+* Safe pruning (never delete deployed configs or their proofs)
+  Dependencies: AQC-603.
+  Parallel: yes.
+
+AQC-605 (P1, 5) Add "reproduce this result" command
+Description: Given a run_id, rerun the same replay/validation steps.
+Acceptance criteria:
+
+* `python3 factory_run.py --reproduce run_id`
+  Dependencies: AQC-401, AQC-603.
+  Parallel: yes.
+
+---
+
+EPIC AQC-E700: Deployment pipeline (paper → live) with safe rollouts
+Goal: remove manual, error-prone promotion; enforce gating.
+
+AQC-701 (P0, 5) Implement "paper deploy" command that installs a selected config safely
+Description: Takes config_id, writes to paper-trading overrides, triggers engine reload/restart as needed, logs deployment event.
+Acceptance criteria:
+
+* Deployment is atomic (no partial writes)
+* Produces `deploy_event.json` with who/what/when/why
+  Dependencies: AQC-603.
+  Parallel: yes (engine integration needed).
+
+AQC-702 (P0, 8) Add promotion gating: validation pass + paper minimums
+Description: Define conditions: "paper ran X trades or Y hours; PF > threshold; slippage within bound; no kill events."
+Acceptance criteria:
+
+* Promotion script refuses if gates not met
+* Gate values configurable
+  Dependencies: AQC-701, AQC-801 (monitoring metrics).
+  Parallel: partial.
+
+AQC-703 (P0, 5) Live rollout ramp (position sizing multiplier)
+Description: Start live at reduced size (e.g., 0.25x), then step up automatically if healthy.
+Acceptance criteria:
+
+* Engine supports a size multiplier
+* Multiplier changes are logged and visible in metrics
+  Dependencies: engine support; AQC-801.
+  Parallel: yes.
+
+AQC-704 (P0, 5) Rollback mechanism (last-known-good config)
+Description: Keep a "golden" fallback config for emergency and automate rollback.
+Acceptance criteria:
+
+* `rollback_to_last_good` command
+* Records rollback reason
+  Dependencies: AQC-603.
+  Parallel: yes.
+
+AQC-705 (P1, 5) Add "interval change orchestration" (30m main requires restart)
+Description: Automate safe restart and WS resubscribe when changing main interval.
+Acceptance criteria:
+
+* Restart is graceful
+* Bot comes back with correct subscriptions
+* If restart fails, bot remains paused
+  Dependencies: your engine controls; AQC-701.
+  Parallel: yes.
+
+AQC-706 (P1, 3) Add deployment dry-run validation
+Description: Validate YAML schema + required fields before deploying.
+Acceptance criteria:
+
+* Fails fast if config invalid
+  Dependencies: AQC-602.
+  Parallel: yes.
+
+---
+
+EPIC AQC-E800: Live risk controls and kill switches (hard + soft)
+Goal: survive inevitable regime shifts and bad fills. This is where "earning money" becomes "not losing it all."
+
+AQC-801 (P0, 8) Implement structured event logging in trading engine
+Description: Emit machine-readable events for: order placed, filled, rejected, position opened/closed, kill switch triggered, mode changed.
+Acceptance criteria:
+
+* Events are written to JSONL with stable schema version
+* Includes timestamps, symbol, config_id, run_id
+  Dependencies: none.
+  Parallel: yes.
+
+AQC-802 (P0, 8) Equity drawdown kill switch (peak-to-valley)
+Description: If DD exceeds threshold, bot pauses new entries and optionally closes positions according to policy.
+Acceptance criteria:
+
+* Configurable threshold
+* Clear behaviour: "pause entries" and "reduce risk"
+* Emits kill event and requires explicit resume condition
+  Dependencies: AQC-801.
+  Parallel: yes.
+
+AQC-803 (P0, 5) Daily loss limit kill switch (UTC day)
+Description: Track realized PnL per UTC day; stop if below threshold.
+Acceptance criteria:
+
+* Reset at UTC day boundary
+* Emits kill event
+  Dependencies: AQC-801.
+  Parallel: yes.
+
+AQC-804 (P0, 8) Slippage anomaly guard
+Description: If live slippage exceeds stress-tested expectations (e.g., > X bps median over last N fills), pause.
+Acceptance criteria:
+
+* Computes live slippage from fills vs mid/BBO
+* Triggers pause and logs
+  Dependencies: AQC-801.
+  Parallel: yes.
+
+AQC-805 (P1, 5) "Performance degradation" soft stop
+Description: Rolling PF/WR/Sh (over last N trades or last T hours). If below threshold, pause or switch to conservative mode.
+Acceptance criteria:
+
+* Configurable windows and thresholds
+* Avoids triggering with too few trades (min sample)
+  Dependencies: AQC-801.
+  Parallel: yes.
+
+AQC-806 (P1, 8) Portfolio heat limit (risk budget)
+Description: Cap total open risk (e.g., sum of per-position stop distance * size) as % of equity.
+Acceptance criteria:
+
+* New entries rejected if heat > limit
+* Logged decisions
+  Dependencies: engine position model; AQC-801.
+  Parallel: yes.
+
+AQC-807 (P1, 5) Exposure concentration limit (max correlated bets)
+Description: Limit number of same-direction positions in highly correlated assets; optionally use BTC beta proxy.
+Acceptance criteria:
+
+* Simple first version: cap max simultaneous longs/shorts in "alts" bucket
+* Logs when signals are skipped due to exposure rules
+  Dependencies: AQC-801.
+  Parallel: yes.
+
+AQC-808 (P2, 8) Emergency "flat now" command + safe unwind policy
+Description: For incidents, flatten positions with a defined policy.
+Acceptance criteria:
+
+* One command triggers flatten and pause
+* Policy documented and tested in paper
+  Dependencies: engine capabilities.
+  Parallel: later.
+
+---
+
+EPIC AQC-E900: Observability, dashboards, and daily reporting
+Goal: turn this into an auditable production system with rapid feedback.
+
+AQC-901 (P0, 5) Daily summary report generator (paper + live)
+Description: Generate a daily markdown/HTML report with key metrics, config_id, kill events, PnL, DD, slippage.
+Acceptance criteria:
+
+* Runs from logs + registry
+* Stored under artifacts
+  Dependencies: AQC-603, AQC-801.
+  Parallel: yes.
+
+AQC-902 (P0, 5) Real-time health dashboard (minimal viable)
+Description: A simple local web UI or terminal dashboard showing: current mode, config_id, open positions, today PnL, DD, last data timestamp.
+Acceptance criteria:
+
+* Updates at least every 10s
+* Clearly shows "PAUSED" state
+  Dependencies: AQC-801.
+  Parallel: yes.
+
+AQC-903 (P1, 8) Metrics export (Prometheus or JSON aggregator)
+Description: Standard metrics endpoint for Grafana or similar.
+Acceptance criteria:
+
+* Exposes counters/gauges: orders, fills, slippage, PnL, DD, kill events
+  Dependencies: AQC-801.
+  Parallel: yes.
+
+AQC-904 (P1, 5) Alerting (Telegram/Discord/email) on critical events
+Description: Notify on pause/kill, restart, failed nightly pipeline, data gaps.
+Acceptance criteria:
+
+* Alerts triggered only on state changes (avoid spam)
+* Configurable channels
+  Dependencies: AQC-201, AQC-401, AQC-802/803.
+  Parallel: yes.
+
+AQC-905 (P2, 8) Post-trade analytics notebook pack
+Description: Prebuilt analysis scripts for MAE/MFE, symbol contribution, entry/exit reasons.
+Acceptance criteria:
+
+* Works from trade CSV + events
+  Dependencies: AQC-304, AQC-801.
+  Parallel: later.
+
+---
+
+EPIC AQC-E1000: Regime detection + mode switching (trend vs chop) and strategy ensemble
+Goal: stop trading when the strategy's assumptions are false; optionally run multiple modes.
+
+AQC-1001 (P1, 8) Implement "regime gate v1" using existing breadth/ADX/vol metrics
+Description: Define a binary gate: trade only when regime is "trend OK."
+Acceptance criteria:
+
+* Gate is computed on schedule (e.g., every main bar)
+* Trades are blocked when gate is off
+* Gate state logged and visible in dashboard
+  Dependencies: AQC-801.
+  Parallel: yes.
+
+AQC-1002 (P1, 5) Mode switching policy (Primary/Fallback/Conservative/Flat)
+Description: Encode your three-mode plan: 30m/5m DD ↔ 1h/5m DD ↔ 1h/15m DD (or flat).
+Acceptance criteria:
+
+* Automatic switching based on triggers (kill events, performance degradation)
+* Switch events logged with reason
+  Dependencies: AQC-805, AQC-701.
+  Parallel: yes.
+
+AQC-1003 (P2, 13) Add ensemble runner (2–3 strategies concurrently)
+Description: Run multiple configs with risk budgeting across them (not 20 correlated positions each).
+Acceptance criteria:
+
+* Each strategy has an allocation budget
+* Global heat/exposure caps enforced across strategies
+  Dependencies: AQC-806, AQC-807.
+  Parallel: later.
+
+AQC-1004 (P2, 8) Research pipeline for new strategy archetypes (mean reversion, funding arb)
+Description: Scaffold new "strategy modules" that plug into the same factory pipeline.
+Acceptance criteria:
+
+* Template for a new strategy with backtest hooks
+* Can be validated with same suite
+  Dependencies: AQC-E500/E600 stable.
+  Parallel: later.
+
+---
+
+EPIC AQC-E1100: CI/CD, testing, and ops hardening
+Goal: make changes safe, repeatable, and less fragile under WSL2/GPU constraints.
+
+AQC-1101 (P0, 5) Add config schema validation + type coercion tests
+Description: Ensure YAML parsing and coercion rules are locked and tested.
+Acceptance criteria:
+
+* Unit tests for coercion (int/bool/enum rounding)
+* CI fails if config schema breaks
+  Dependencies: none.
+  Parallel: yes.
+
+AQC-1102 (P0, 5) Add integration test: "factory smoke run" on fixture dataset
+Description: Run minimal pipeline on a small dataset (CPU-only) to ensure orchestration doesn't break.
+Acceptance criteria:
+
+* CI job completes and produces artifacts
+  Dependencies: AQC-401.
+  Parallel: yes.
+
+AQC-1103 (P1, 8) Build/release automation for `mei-backtester` binaries (CPU + GPU)
+Description: Standardize how binaries are built and versioned; store build metadata.
+Acceptance criteria:
+
+* Version stamped into binary
+* Pipeline records build info in run_metadata
+  Dependencies: AQC-404.
+  Parallel: yes.
+
+AQC-1104 (P1, 5) System service management (systemd/cron) for nightly runs + engine
+Description: Ensure nightly pipeline runs reliably and logs are rotated.
+Acceptance criteria:
+
+* Service/timer definitions in repo
+* Logs rotated and retained per policy
+  Dependencies: AQC-401.
+  Parallel: yes.
+
+AQC-1105 (P2, 8) Secrets management for alerting channels / API keys
+Description: Avoid secrets in repo; use environment or vault.
+Acceptance criteria:
+
+* Documented setup
+* No secrets committed
+  Dependencies: AQC-904.
+  Parallel: yes.
+
+---
+
+What can be done in parallel (workstreams + dependency notes)
+
+Workstream 1: Data reliability and history (can run mostly parallel)
+
+* AQC-E200 (data checks + append-only retention) can start immediately.
+* Minimal dependencies: none. This is a high-leverage track because longer 3m/5m history improves every other epic's signal-to-noise ratio.
+
+Workstream 2: Replay enhancements (parallel, but critical-path enabling)
+
+* AQC-301/302/303 are blockers for serious validation. Start them immediately.
+* These can be developed in parallel with orchestrator scaffolding by stubbing outputs.
+
+Workstream 3: Orchestrator + artifacts/registry (parallel)
+
+* AQC-E400 and AQC-E600 can start early even while replay features are landing (mock data).
+* Once replay features are ready, plug them in.
+
+Workstream 4: Validation suite (depends on replay time slicing + per-symbol stats)
+
+* AQC-501 needs AQC-301.
+* AQC-503 needs AQC-302.
+* AQC-502 needs AQC-303.
+* The scoring (AQC-504) and reject reporting (AQC-507) can be designed in parallel and integrated after.
+
+Workstream 5: Engine risk controls + logging (parallel with everything; also critical path)
+
+* AQC-E800 can begin immediately.
+* AQC-801 (event logging) is a dependency for dashboards and promotion gating, but you can implement kill switches in parallel if you ensure they also emit events.
+
+Workstream 6: Deployment & promotion (depends on registry + engine events)
+
+* AQC-701 can start once registry basics exist (AQC-603) and engine can consume config_id/run_id.
+* Promotion gating (AQC-702) should wait until events + daily reports exist.
+
+Workstream 7: Observability (depends on event logging)
+
+* AQC-901/902 can start once AQC-801 exists (even with minimal events).
+
+Workstream 8: Regime switching and ensemble (do after stability)
+
+* AQC-E1000 is best tackled after kill switches + pipeline are stable, otherwise you'll add complexity before you can trust the basics.
+
+Critical path (the shortest chain to a safe end-to-end system)
+
+1. AQC-201/202 (data gating)
+2. AQC-301/303/302 (replay time range + slippage override + per-symbol metrics)
+3. AQC-401/403/601/603 (orchestrator + shortlist + artifacts + registry)
+4. AQC-502/503/504 (stress tests + concentration + score)
+5. AQC-801/802/803 (events + core kill switches)
+6. AQC-701 (paper deploy) → AQC-901 (daily report)
+   Then you have a loop that can run daily without blowing up silently.
+
+Suggested initial "Sprint 1" scope (if you want a coherent first deliverable)
+
+* Data gates: AQC-201, AQC-202
+* Replay enablers: AQC-301, AQC-303, AQC-302
+* Event logging: AQC-801
+* Orchestrator skeleton + artifacts: AQC-401, AQC-601
+  Deliverable: one command that runs checks + a replay suite on an existing config and produces a report + artifacts.
+
+Suggested "Sprint 2" scope (turn it into the strategy factory)
+
+* Sweep runner + config shortlist: AQC-402, AQC-403
+* Validation suite core: AQC-501, AQC-502, AQC-503, AQC-504, AQC-507
+* Kill switches core: AQC-802, AQC-803
+  Deliverable: nightly run produces ranked shortlist with reject reasons and can auto-pause trading if limits hit.
+
+Suggested "Sprint 3" scope (controlled deployment)
+
+* Paper deploy: AQC-701
+* Rollback: AQC-704
+* Ramp: AQC-703
+* Daily report + minimal dashboard: AQC-901, AQC-902
+  Deliverable: paper→live workflow with guardrails and observability.
+
+If you want, I can also provide a Jira import-friendly CSV outline (Epic, Issue Type, Summary, Description, Acceptance Criteria, Priority, Points, Dependencies, Labels).

--- a/plan/1/strategy-factory-workflow.md
+++ b/plan/1/strategy-factory-workflow.md
@@ -1,0 +1,332 @@
+What your report is really saying is: you already have the "alpha engine" you need, but the thing that will make (or break) your ability to earn money isn't finding *the* best config. It's building a repeatable "strategy factory" loop that (1) generates candidates fast, (2) rejects the ones that only look good in-sample, (3) deploys small with strict risk limits, and (4) rotates/pauses quickly when the edge decays.
+
+Below is a high-level strategy and a concrete workflow you can automate using the exact components you already have (GPU TPE sweep → config generation → CPU replay → deploy).
+
+---
+
+First, here's the clean interpretation of your findings (this is the foundation of the workflow):
+
+1. Your GPU sweeps are an excellent **candidate generator**, not a truth oracle.
+   You proved this yourself: on ≥54-day periods, GPU and CPU disagree on the sign of PnL. That means GPU is producing "false winners" when the evaluation horizon is long and the simulation is mismatched (f32 + simplified trade logic + main-bar-only exits).
+
+2. CPU replay (with sub-bar entry/exit) is the closest thing you have to "truth."
+   So the correct posture is: GPU proposes, CPU disposes.
+
+3. Sub-bar exits (3m/5m) are not a small detail; they are the strategy.
+   Everything else (EMA windows, thresholds, etc.) is secondary compared to exit granularity and risk controls. In other words, your "edge" is partly: "manage risk intrabar, don't let coarse bars lie."
+
+4. "Best DD" beating "Best PnL" on CPU is a giant hint about robustness.
+   It usually means your system is over-optimising for lucky paths and compounding artifacts, and DD-optimisation is acting like a regulariser.
+
+5. Your current data retention effectively forces a short-horizon business model.
+   Right now, your 3m DB is 12 days and 5m DB is 19 days. That means you literally cannot validate 3m/5m strategies over months, even if the strategy might work longer. So the "2–3 week lifespan" conclusion may be partly real regime decay, and partly "you can only see 2–3 weeks."
+
+That leads to the only high-level approach that fits your reality:
+
+You're not building "one strategy that wins."
+You're building a system that repeatedly manufactures a small, temporary edge and keeps risk bounded when the edge disappears.
+
+---
+
+Now the high-level strategy that's consistent with your results
+
+A practical, automatable strategy for your setup is:
+
+A regime-aware, risk-first momentum system with rapid rotation.
+
+• Signal family: your existing momentum/breadth/volume-confirmed trend logic (mei_alpha_v1).
+• Execution granularity: always trade with 5m (or 3m) entry/exit resolution.
+• Parameter philosophy: optimise for drawdown / stability first, not peak PnL.
+• Lifecycle assumption: parameters expire; treat configs as perishable.
+• Risk philosophy: portfolio risk limits matter more than indicator tweaks.
+• Operational model: "always-on pipeline" that continuously evaluates and swaps configs under guardrails.
+
+This matches exactly what your best result is telling you: 30m main with 5m sub-bars + DD-optimised parameters is your current "best-known production mode."
+
+---
+
+The actionable, repeatable, automatable workflow
+
+Think of it as five loops running on different clocks:
+
+A) Data integrity loop (continuous)
+B) Candidate generation loop (nightly / daily)
+C) Robust validation loop (nightly, after candidate gen)
+D) Deployment loop (controlled, gated)
+E) Live monitoring + kill-switch loop (continuous)
+
+I'll describe each in the way you can actually implement with your current repo.
+
+---
+
+A) Data integrity loop (continuous)
+
+If this part is weak, everything downstream becomes self-deception.
+
+1. Verify DB completeness per interval daily
+
+* Check that each DB has the expected number of bars per symbol (or at least no sudden gaps).
+* Alert if a symbol stops updating, because missing candles create phantom edges.
+
+2. Persist more than 5000 bars going forward (if possible in your sidecar)
+   Right now, you're effectively capped by HL's last-5000 retention *as stored*. The single biggest upgrade you can make to "earn money sustainably" is to turn the sidecar storage into an append-only history so your 3m/5m windows eventually become 90–180 days.
+
+This is important because it changes your entire business model:
+
+* With 12–19 days of data, you must rotate constantly.
+* With 90–180 days of 5m data, you can actually test whether 30m/5m DD is robust across regimes.
+
+If you do only one infrastructure upgrade, do this.
+
+---
+
+B) Candidate generation loop (nightly/daily)
+
+Goal: generate a small set of candidate configs quickly, using GPU only where it's reliable.
+
+Based on your evidence, keep GPU sweep usage inside the zone where it's directionally correct:
+
+* Main: 30m and/or 1h
+* Sub-bar: 3m or 5m
+* Horizon: whatever your 3m/5m DB supports (12–19 days today)
+
+Practical approach:
+
+1. Run 2 sweeps nightly:
+
+* 30m/5m (primary mode)
+* 1h/5m (fallback mode that avoids restart complexity if you prefer)
+
+2. Don't do 500k trials nightly
+   Your 500k sweeps are great for occasional deep dives, but in a daily pipeline you want "good enough candidates fast." You can do something like 50k–150k trials per combo nightly, then periodically do a 500k "refresh" on weekends.
+
+3. Generate not just rank #1, generate a shortlist
+   For each sweep output, produce:
+
+* Top 10 by DD
+* Top 10 by "balanced"
+* (Optionally) top 10 by PF or Sharpe, but only if you enforce a min-trades constraint
+
+Why? Because your live choice should be based on out-of-sample stability, not in-sample rank.
+
+You already have the tooling for this (`generate_config.py`). You'd just call it in a loop.
+
+---
+
+C) Robust validation loop (nightly)
+
+This is the critical missing layer between "backtest winners" and "something you can trade."
+
+Your current "apple-to-apple 12 days, force 3m entry/exit" replay is a good comparability tool, but it's not a robustness test by itself because:
+
+* it's still in-sample relative to the sweep window,
+* 12 days is too short to trust Sharpe,
+* and you're doing heavy multiple testing (500k trials).
+
+So the validation loop needs to introduce "friction" and "out-of-sample pressure" in a way you can automate now, even with short data.
+
+Here's a validation protocol that fits your constraints:
+
+1. Multi-split walk-forward on the short window
+   Even with 19 days, you can do a few splits.
+
+Example for a 19-day 5m dataset:
+
+* Split 1: train days 1–12, test days 13–19
+* Split 2: train days 4–15, test days 16–19
+* Split 3: train days 1–9,  test days 10–19  (more aggressive OOS)
+
+Mechanically, you need the ability to replay on specific subranges. If your CLI doesn't support explicit start/end yet, add it. This one feature pays for itself immediately.
+
+2. Slippage/fee stress test
+   Right now you assume 10 bps slippage. In real alts/perps, your realized slippage can be much worse during spikes.
+
+Nightly, replay each candidate at:
+
+* 10 bps (baseline)
+* 20 bps (realistic stress)
+* 30 bps (bad conditions)
+
+Reject configs that flip sign or blow up DD under modest friction.
+
+If your engine only supports slippage via config, generate variants automatically (same config, different `slippage_bps`).
+
+3. Concentration checks
+   A config that makes all its money on 1–2 symbols will "feel great" until it dies.
+
+For each candidate, compute:
+
+* % of PnL from top 1 symbol
+* % of PnL from top 5 symbols
+* long vs short contribution
+* number of distinct symbols traded
+
+Reject candidates that are too concentrated.
+
+4. Stability score (one number to rank candidates)
+   You need a single scalar score to pick "best for live." A simple one you can automate is:
+
+score = median(OOS_daily_return)
+− 2.0 * max(OOS_drawdown)
+− 0.5 * (PnL_drop_when_slippage_20bps)
+− penalty_if_trades_too_low
+
+This does three important things:
+
+* rewards out-of-sample performance,
+* punishes tail risk (drawdown),
+* punishes fragility to friction.
+
+The exact weights don't matter as much as having a consistent rule and logging outcomes.
+
+---
+
+D) Deployment loop (controlled + gated)
+
+Your deployment should not be "deploy the #1 backtest config." It should be:
+
+1. Deploy to paper first (always)
+
+* Pick top 1–3 validated candidates.
+* Run them paper for a fixed minimum sample (e.g., 1 trading day or N trades).
+* Log live-style metrics: fills, slippage, funding, latency, rejection rate.
+
+2. Promote to live with a ramp
+   Because your bankroll is small and you're using leverage, your biggest enemy is variance + a few bad fills.
+
+A simple ramp rule:
+
+* Start at 25% of intended size for the first day.
+* If no kill-switch triggers and slippage is within bounds, step up.
+* If something looks off, step down or pause.
+
+3. Version everything
+   Every deployment should write:
+
+* config hash / git commit
+* sweep file ref
+* validation report ref
+* start timestamp
+* stop timestamp + reason (rotated, killed, decayed)
+
+This turns your trading into an engineering process instead of a feeling.
+
+---
+
+E) Live monitoring + kill switches (continuous)
+
+This is where most "profitable backtests" go to die. You want your bot to stop itself before it ruins you.
+
+Minimum viable kill switches you can automate today:
+
+1. Equity drawdown kill
+   If peak-to-valley drawdown exceeds X%, stop trading and go to "safe mode" (or flat).
+   Pick X so you can survive, not so you can "maximize returns."
+
+2. Daily loss limit
+   If today's realized PnL < −Y%, stop trading until next UTC day.
+
+3. Performance degradation trigger
+   Compute rolling live PF / Sharpe / win rate over last N trades or last 24h:
+
+* If PF < 1.0 after at least (say) 30 trades, pause.
+* If slippage exceeds your stress-tested expectations, pause.
+
+4. Regime gate (you already have breadth)
+   Since your strategy is momentum-flavored, don't force it to trade mean-reverting chop.
+   Add a "do not trade" gate if breadth/trend metrics indicate chop (whatever definition your code supports).
+
+Even a crude regime gate often improves survivability more than another 500k sweep.
+
+---
+
+What to do with your current best configs (practical plan)
+
+Given your report, a very pragmatic "three-mode" system is:
+
+Mode 1 (Primary): 30m/5m DD
+
+* Use when market is trending / breadth supportive.
+* This is your best current performer on the comparable 12-day test and profitable on its 19-day native window.
+
+Mode 2 (Fallback): 1h/5m DD
+
+* Use when you want less operational complexity (no main interval restart) or if 30m mode degrades.
+* Also profitable on the 19-day window.
+
+Mode 3 (Safety / Recovery): 1h/15m DD (or flat)
+
+* Use when volatility gets weird or chop increases and you want minimal DD.
+* Not because it "earns the most," but because it helps you not die.
+
+Then automate switching rules:
+
+* If Mode 1 violates kill-switch thresholds → switch to Mode 2 or Mode 3.
+* If Mode 2 also violates → go Mode 3 or flat.
+* When conditions recover and your nightly validation says Mode 1 is healthy again → return.
+
+This turns your single strategy into a regime-aware system without writing an entirely new alpha.
+
+---
+
+Two important "understanding" points that will save you months
+
+1. Your 12-day +239% result is not a target; it's a symptom of high variance and multiple testing.
+   Over short windows, returns can look insane. The job of the workflow is not to chase that number; it's to make sure your live process doesn't blow up when the inevitable bad streak arrives.
+
+2. Right now, your limiting factor is not TPE or GPU speed. It's out-of-sample evidence.
+   With 12–19 days of high-resolution data, you can't honestly claim robustness. So either:
+
+* accept the "short-lived edge + rapid rotation" business model, or
+* invest in building longer 3m/5m history so you can validate properly.
+
+That's the fork in the road.
+
+---
+
+A concrete automation blueprint (how it looks as a daily pipeline)
+
+This is what I would automate first, using your existing CLI pieces:
+
+Every night (UTC):
+
+1. Update funding DB (`fetch_funding_rates.py`) and confirm candle DB freshness.
+2. Run GPU sweeps:
+
+   * 30m/5m with (say) 100k–200k trials
+   * 1h/5m with (say) 100k–200k trials
+3. Generate top candidates:
+
+   * top 10 by DD
+   * top 10 by balanced
+4. Run CPU validation suite for each candidate:
+
+   * native interval replay (5m/5m) on full available range
+   * 2–3 walk-forward splits (if you add time range control)
+   * slippage stress (10/20/30 bps)
+   * concentration metrics
+5. Pick top 1–3 configs by your stability score.
+6. Deploy best config to paper for the next session (or keep current live if it's still healthy).
+7. If live is enabled, only promote a config that passed validation + paper gates.
+
+During the day:
+
+* Monitor live stats and enforce kill switches.
+* If killed, immediately fall back to safety mode (or flat), and wait for next nightly cycle to propose replacements.
+
+This is actionable, repeatable, and automatable with what you already built.
+
+---
+
+One last thing: there are inconsistencies in the parameter snippet you included
+
+In your "Top Performer: 30m/5m DD" YAML snippet, values like `ema_fast_window: 5`, `allocation_pct: 0.109937`, and `leverage: 4.574699` don't match the sweep ranges you listed earlier (e.g., ema_fast_window was shown as [9–13], allocation_pct [0.17–0.30], leverage [3.0–4.3]). That doesn't change the high-level conclusion, but it does mean: treat `/tmp/config_30m5m_best_dd.yaml` as the source of truth and don't rely on the snippet when deploying.
+
+---
+
+If you want the shortest path to "something that can actually run," do this:
+
+* Run 30m/5m DD in paper immediately, but add strict kill-switches and a daily validation pipeline.
+* In parallel, modify your data storage so 3m/5m history grows beyond 12–19 days. That one change massively improves your ability to validate and reduces the need for frantic parameter rotation.
+
+If you want, I can also outline exactly what to log (fields/events) so you can later answer the only question that matters: "When this thing made or lost money live, why?"


### PR DESCRIPTION
## Summary
- Add planning notes under `plan/`:
  - Scrum-ready backlog
  - Strategy factory workflow

## Notes
Content uses UK English spelling and is intended as internal planning documentation.