### PR TITLE
AQC-205: Universe history tracking + backtest universe filter

### DIFF
--- a/backtester/README.md
+++ b/backtester/README.md
@@ -30,6 +30,17 @@ mei-backtester sweep --sweep-config sweep.yaml [OPTIONS]
 mei-backtester dump-indicators --symbol BTC [OPTIONS]
 ```
 
+### Universe filter (AQC-205)
+
+If you maintain a universe history DB via `tools/sync_universe_history.py`, you can optionally filter backtests to symbols that were active during the tested period:
+
+```bash
+mei-backtester replay --universe-filter
+mei-backtester sweep --universe-filter
+```
+
+The universe DB defaults to `<candles_db_dir>/universe_history.db`. Override with `--universe-db`.
+
 ---
 
 ## Config Deploy Pipeline

--- a/backtester/crates/bt-cli/src/main.rs
+++ b/backtester/crates/bt-cli/src/main.rs
@@ -5,8 +5,9 @@
 //!   - `sweep`           — Parallel parameter sweep (Cartesian product of axes)
 //!   - `dump-indicators` — Dump raw indicator values as CSV for debugging
 
+use std::collections::HashSet;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use clap::{Parser, Subcommand};
@@ -136,6 +137,20 @@ struct ReplayArgs {
     #[arg(long)]
     to_ts: Option<i64>,
 
+    /// Filter the candle universe to symbols active during the backtest window using
+    /// `universe_listings` from a universe history DB (see tools/sync_universe_history.py).
+    ///
+    /// A symbol is considered active when its observed listing interval overlaps with
+    /// the backtest window:
+    ///   first_seen_ms <= to_ts AND last_seen_ms >= from_ts
+    #[arg(long, default_value_t = false)]
+    universe_filter: bool,
+
+    /// Path to the universe history SQLite DB.
+    /// If omitted, auto-resolved as: <candles_db_dir>/universe_history.db
+    #[arg(long)]
+    universe_db: Option<String>,
+
     /// Disable auto-scoping. By default, replay auto-scopes all candle DBs to the
     /// shortest overlapping time range for apple-to-apple comparison.
     /// Use --no-auto-scope to disable this and rely on explicit --from-ts / --to-ts.
@@ -220,6 +235,20 @@ struct SweepArgs {
     /// End timestamp in milliseconds (inclusive). Only trade on bars <= this time.
     #[arg(long)]
     to_ts: Option<i64>,
+
+    /// Filter the candle universe to symbols active during the sweep window using
+    /// `universe_listings` from a universe history DB (see tools/sync_universe_history.py).
+    ///
+    /// A symbol is considered active when its observed listing interval overlaps with
+    /// the sweep window:
+    ///   first_seen_ms <= to_ts AND last_seen_ms >= from_ts
+    #[arg(long, default_value_t = false)]
+    universe_filter: bool,
+
+    /// Path to the universe history SQLite DB.
+    /// If omitted, auto-resolved as: <candles_db_dir>/universe_history.db
+    #[arg(long)]
+    universe_db: Option<String>,
 
     /// Disable auto-scoping. By default, sweep auto-scopes all candle DBs to the
     /// shortest overlapping time range for apple-to-apple comparison.
@@ -323,13 +352,38 @@ fn compute_auto_scope(
 }
 
 // ---------------------------------------------------------------------------
+// Universe filtering helpers (survivorship bias mitigation)
+// ---------------------------------------------------------------------------
+
+fn default_universe_db_path(candles_db: &str) -> String {
+    let p = Path::new(candles_db);
+    let dir = p.parent().unwrap_or_else(|| Path::new("."));
+    dir.join("universe_history.db").to_string_lossy().to_string()
+}
+
+fn infer_candle_range_ms(candles: &bt_core::candle::CandleData) -> Option<(i64, i64)> {
+    let mut min_t: Option<i64> = None;
+    let mut max_t: Option<i64> = None;
+    for bars in candles.values() {
+        if let Some(first) = bars.first() {
+            min_t = Some(min_t.map_or(first.t, |m| m.min(first.t)));
+        }
+        if let Some(last) = bars.last() {
+            max_t = Some(max_t.map_or(last.t, |m| m.max(last.t)));
+        }
+    }
+    min_t.zip(max_t)
+}
+
+// ---------------------------------------------------------------------------
 // Subcommand implementations
 // ---------------------------------------------------------------------------
 
 fn cmd_replay(args: ReplayArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let symbol_norm = args.symbol.as_ref().map(|s| s.trim().to_uppercase());
     let cfg = bt_core::config::load_config(
         &args.config,
-        args.symbol.as_deref(),
+        symbol_norm.as_deref(),
         args.live,
     );
 
@@ -372,7 +426,7 @@ fn cmd_replay(args: ReplayArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!(
         "[replay] Config loaded from {:?} (live={}, symbol={:?})",
-        args.config, args.live, args.symbol,
+        args.config, args.live, symbol_norm,
     );
     eprintln!(
         "[replay] Indicator interval: {} (db: {})",
@@ -413,15 +467,15 @@ fn cmd_replay(args: ReplayArgs) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Load indicator candles (full history for warmup — no time filter)
-    let candles = bt_data::sqlite_loader::load_candles(&candles_db, &interval)?;
+    let mut candles = bt_data::sqlite_loader::load_candles(&candles_db, &interval)?;
 
     if candles.is_empty() {
         eprintln!("[replay] No candles found. Check --candles-db and --interval.");
         std::process::exit(1);
     }
 
-    // If --symbol specified, verify it exists in the candle data
-    if let Some(ref sym) = args.symbol {
+    // If --symbol specified, verify it exists in the candle data (normalised to uppercase)
+    if let Some(ref sym) = symbol_norm {
         if !candles.contains_key(sym) {
             let mut available: Vec<&String> = candles.keys().collect();
             available.sort();
@@ -429,6 +483,62 @@ fn cmd_replay(args: ReplayArgs) -> Result<(), Box<dyn std::error::Error>> {
                 "[replay] Symbol {:?} not found in candle DB. Available: {:?}",
                 sym, available,
             );
+            std::process::exit(1);
+        }
+    }
+
+    // Optional: filter candle universe to active symbols from universe_history.db
+    let mut keep_symbols: Option<HashSet<String>> = None;
+    if args.universe_filter {
+        let (min_t, max_t) = infer_candle_range_ms(&candles).unwrap_or_else(|| {
+            eprintln!("[replay] No candle timestamps found.");
+            std::process::exit(1);
+        });
+        let filter_from = from_ts.unwrap_or(min_t);
+        let filter_to = to_ts.unwrap_or(max_t);
+        if filter_from > filter_to {
+            eprintln!("[replay] Invalid time range: from_ts > to_ts ({} > {})", filter_from, filter_to);
+            std::process::exit(1);
+        }
+
+        let universe_db = args.universe_db.clone().unwrap_or_else(|| default_universe_db_path(&candles_db));
+
+        eprintln!(
+            "[replay] Universe filter enabled: range={}..{}, db={}",
+            filter_from, filter_to, universe_db,
+        );
+        let active = bt_data::sqlite_loader::load_universe_active_symbols(&universe_db, filter_from, filter_to)
+            .unwrap_or_else(|e| { eprintln!("[replay] Universe filter failed: {e}"); std::process::exit(1); });
+        if active.is_empty() {
+            eprintln!("[replay] Universe filter returned 0 active symbols (range={}..{})", filter_from, filter_to);
+            std::process::exit(1);
+        }
+        keep_symbols = Some(active.into_iter().collect());
+    }
+
+    // If --symbol specified, restrict to a single symbol (and validate against universe filter if enabled).
+    if let Some(ref sym) = symbol_norm {
+        if let Some(ref keep) = keep_symbols {
+            if !keep.contains(sym) {
+                eprintln!(
+                    "[replay] Symbol {:?} is not active in the universe history DB for the selected window.",
+                    sym,
+                );
+                std::process::exit(1);
+            }
+        }
+        let mut single = HashSet::new();
+        single.insert(sym.clone());
+        keep_symbols = Some(single);
+    }
+
+    // Apply final symbol filter to indicator candles
+    if let Some(ref keep) = keep_symbols {
+        let before = candles.len();
+        candles.retain(|sym, _| keep.contains(sym));
+        eprintln!("[replay] Symbol universe: {before} -> {} symbols", candles.len());
+        if candles.is_empty() {
+            eprintln!("[replay] No candles left after symbol filtering.");
             std::process::exit(1);
         }
     }
@@ -441,7 +551,10 @@ fn cmd_replay(args: ReplayArgs) -> Result<(), Box<dyn std::error::Error>> {
     let exit_candles = if let Some(ref exit_db) = exit_candles_db {
         let exit_iv = exit_interval.as_deref().unwrap_or(&interval);
         eprintln!("[replay] Loading exit candles from {:?} (interval={})", exit_db, exit_iv);
-        let ec = bt_data::sqlite_loader::load_candles_filtered(exit_db, exit_iv, from_ts, to_ts)?;
+        let mut ec = bt_data::sqlite_loader::load_candles_filtered(exit_db, exit_iv, from_ts, to_ts)?;
+        if let Some(ref keep) = keep_symbols {
+            ec.retain(|sym, _| keep.contains(sym));
+        }
         let ec_bars: usize = ec.values().map(|v| v.len()).sum();
         eprintln!("[replay] Exit candles: {} bars across {} symbols", ec_bars, ec.len());
         Some(ec)
@@ -453,7 +566,10 @@ fn cmd_replay(args: ReplayArgs) -> Result<(), Box<dyn std::error::Error>> {
     let entry_candles = if let Some(ref entry_db) = entry_candles_db {
         let entry_iv = entry_interval.as_deref().unwrap_or(&interval);
         eprintln!("[replay] Loading entry candles from {:?} (interval={})", entry_db, entry_iv);
-        let nc = bt_data::sqlite_loader::load_candles_filtered(entry_db, entry_iv, from_ts, to_ts)?;
+        let mut nc = bt_data::sqlite_loader::load_candles_filtered(entry_db, entry_iv, from_ts, to_ts)?;
+        if let Some(ref keep) = keep_symbols {
+            nc.retain(|sym, _| keep.contains(sym));
+        }
         let nc_bars: usize = nc.values().map(|v| v.len()).sum();
         eprintln!("[replay] Entry candles: {} bars across {} symbols", nc_bars, nc.len());
         Some(nc)
@@ -464,7 +580,10 @@ fn cmd_replay(args: ReplayArgs) -> Result<(), Box<dyn std::error::Error>> {
     // Optional: load funding rates (filtered)
     let funding_rates = if let Some(ref fdb) = args.funding_db {
         eprintln!("[replay] Loading funding rates from {:?}", fdb);
-        let fr = bt_data::sqlite_loader::load_funding_rates_filtered(fdb, from_ts, to_ts)?;
+        let mut fr = bt_data::sqlite_loader::load_funding_rates_filtered(fdb, from_ts, to_ts)?;
+        if let Some(ref keep) = keep_symbols {
+            fr.retain(|sym, _| keep.contains(sym));
+        }
         let fr_count: usize = fr.values().map(|v| v.len()).sum();
         eprintln!("[replay] Funding rates: {} entries across {} symbols", fr_count, fr.len());
         Some(fr)
@@ -625,10 +744,50 @@ fn cmd_sweep(args: SweepArgs) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Load indicator candles (full history for warmup — no time filter)
-    let candles = bt_data::sqlite_loader::load_candles(&candles_db, &interval)?;
+    let mut candles = bt_data::sqlite_loader::load_candles(&candles_db, &interval)?;
     if candles.is_empty() {
         eprintln!("[sweep] No candles found. Check --candles-db.");
         std::process::exit(1);
+    }
+
+    // Optional: filter candle universe to active symbols from universe_history.db
+    let mut keep_symbols: Option<HashSet<String>> = None;
+    if args.universe_filter {
+        let (min_t, max_t) = infer_candle_range_ms(&candles).unwrap_or_else(|| {
+            eprintln!("[sweep] No candle timestamps found.");
+            std::process::exit(1);
+        });
+        let filter_from = from_ts.unwrap_or(min_t);
+        let filter_to = to_ts.unwrap_or(max_t);
+        if filter_from > filter_to {
+            eprintln!("[sweep] Invalid time range: from_ts > to_ts ({} > {})", filter_from, filter_to);
+            std::process::exit(1);
+        }
+
+        let universe_db = args.universe_db.clone().unwrap_or_else(|| default_universe_db_path(&candles_db));
+
+        eprintln!(
+            "[sweep] Universe filter enabled: range={}..{}, db={}",
+            filter_from, filter_to, universe_db,
+        );
+        let active = bt_data::sqlite_loader::load_universe_active_symbols(&universe_db, filter_from, filter_to)
+            .unwrap_or_else(|e| { eprintln!("[sweep] Universe filter failed: {e}"); std::process::exit(1); });
+        if active.is_empty() {
+            eprintln!("[sweep] Universe filter returned 0 active symbols (range={}..{})", filter_from, filter_to);
+            std::process::exit(1);
+        }
+        keep_symbols = Some(active.into_iter().collect());
+    }
+
+    // Apply final symbol filter to indicator candles
+    if let Some(ref keep) = keep_symbols {
+        let before = candles.len();
+        candles.retain(|sym, _| keep.contains(sym));
+        eprintln!("[sweep] Symbol universe: {before} -> {} symbols", candles.len());
+        if candles.is_empty() {
+            eprintln!("[sweep] No candles left after symbol filtering.");
+            std::process::exit(1);
+        }
     }
 
     let num_symbols = candles.len();
@@ -638,7 +797,10 @@ fn cmd_sweep(args: SweepArgs) -> Result<(), Box<dyn std::error::Error>> {
     // Load exit candles (filtered)
     let exit_candles = if let Some(ref exit_db) = exit_candles_db {
         let exit_iv = exit_interval.as_deref().unwrap_or(&interval);
-        let ec = bt_data::sqlite_loader::load_candles_filtered(exit_db, exit_iv, from_ts, to_ts)?;
+        let mut ec = bt_data::sqlite_loader::load_candles_filtered(exit_db, exit_iv, from_ts, to_ts)?;
+        if let Some(ref keep) = keep_symbols {
+            ec.retain(|sym, _| keep.contains(sym));
+        }
         let ec_bars: usize = ec.values().map(|v| v.len()).sum();
         eprintln!("[sweep] Exit candles: {} bars across {} symbols", ec_bars, ec.len());
         Some(ec)
@@ -649,7 +811,10 @@ fn cmd_sweep(args: SweepArgs) -> Result<(), Box<dyn std::error::Error>> {
     // Load entry candles (filtered)
     let entry_candles = if let Some(ref entry_db) = entry_candles_db {
         let entry_iv = entry_interval.as_deref().unwrap_or(&interval);
-        let nc = bt_data::sqlite_loader::load_candles_filtered(entry_db, entry_iv, from_ts, to_ts)?;
+        let mut nc = bt_data::sqlite_loader::load_candles_filtered(entry_db, entry_iv, from_ts, to_ts)?;
+        if let Some(ref keep) = keep_symbols {
+            nc.retain(|sym, _| keep.contains(sym));
+        }
         let nc_bars: usize = nc.values().map(|v| v.len()).sum();
         eprintln!("[sweep] Entry candles: {} bars across {} symbols", nc_bars, nc.len());
         Some(nc)
@@ -659,7 +824,10 @@ fn cmd_sweep(args: SweepArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     // Load funding rates (filtered)
     let funding_rates = if let Some(ref fdb) = args.funding_db {
-        let fr = bt_data::sqlite_loader::load_funding_rates_filtered(fdb, from_ts, to_ts)?;
+        let mut fr = bt_data::sqlite_loader::load_funding_rates_filtered(fdb, from_ts, to_ts)?;
+        if let Some(ref keep) = keep_symbols {
+            fr.retain(|sym, _| keep.contains(sym));
+        }
         let fr_count: usize = fr.values().map(|v| v.len()).sum();
         eprintln!("[sweep] Funding rates: {} entries across {} symbols", fr_count, fr.len());
         Some(fr)

--- a/backtester/crates/bt-data/src/sqlite_loader.rs
+++ b/backtester/crates/bt-data/src/sqlite_loader.rs
@@ -156,6 +156,32 @@ pub fn load_symbols(
     Ok(symbols)
 }
 
+/// Load symbols considered "active" during the given time range using a universe
+/// history SQLite database (see `tools/sync_universe_history.py`).
+///
+/// A symbol is considered active when its observed listing interval overlaps with
+/// the backtest window:
+///   first_seen_ms <= to_ts AND last_seen_ms >= from_ts
+pub fn load_universe_active_symbols(
+    db_path: &str,
+    from_ts: i64,
+    to_ts: i64,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+
+    let mut stmt = conn.prepare(
+        "SELECT symbol FROM universe_listings \
+         WHERE first_seen_ms <= ?2 AND last_seen_ms >= ?1 \
+         ORDER BY symbol",
+    )?;
+
+    let symbols: Vec<String> = stmt
+        .query_map([from_ts, to_ts], |row| row.get(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(symbols)
+}
+
 /// Load funding rates from a SQLite database, returning them grouped by
 /// symbol as sorted Vec<(timestamp_ms, rate)>.
 ///

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -210,6 +210,39 @@ uv run python tools/check_funding_rates_db.py --lookback-hours 72 --max-gap-hour
 uv run python tools/fetch_funding_rates.py --days 7
 ```
 
+### Universe history database (AQC-205)
+
+Tracks when symbols appear/disappear in the Hyperliquid perp universe to support survivorship-bias-aware backtests.
+
+```bash
+# Sync current universe snapshot (recommended: run hourly via cron)
+uv run python tools/sync_universe_history.py
+
+# Inspect derived listing/delisting bounds
+sqlite3 candles_dbs/universe_history.db \
+    "SELECT symbol, first_seen_ms, last_seen_ms FROM universe_listings ORDER BY last_seen_ms DESC LIMIT 20;"
+```
+
+Backtester integration:
+
+```bash
+# Replay with universe filtering enabled (keeps symbols whose listing interval overlaps the backtest window)
+./target/release/mei-backtester replay \
+    --candles-db candles_dbs/candles_5m.db \
+    --config config/strategy_overrides.yaml \
+    --universe-filter
+
+# Sweep with the same filter
+./target/release/mei-backtester sweep \
+    --candles-db candles_dbs/candles_5m.db \
+    --sweep-spec backtester/sweeps/smoke.yaml \
+    --universe-filter
+```
+
+Notes:
+- The universe filter uses `universe_listings.first_seen_ms` / `last_seen_ms` derived from local snapshots. If you have not been running the sync script for the period you are testing, the filter may exclude symbols unexpectedly.
+- The universe DB defaults to `<candles_db_dir>/universe_history.db`, so it follows your `--candles-db` location (useful when running the backtester from within `backtester/`).
+
 ### WebSocket sidecar health
 
 ```bash

--- a/tests/test_universe_history.py
+++ b/tests/test_universe_history.py
@@ -1,0 +1,60 @@
+import sqlite3
+
+from tools.sync_universe_history import apply_snapshot, ensure_schema
+
+
+def _listings(conn: sqlite3.Connection) -> dict[str, tuple[int, int]]:
+    rows = conn.execute("SELECT symbol, first_seen_ms, last_seen_ms FROM universe_listings ORDER BY symbol").fetchall()
+    return {str(sym): (int(first), int(last)) for (sym, first, last) in rows}
+
+
+def test_apply_snapshot_derives_first_and_last_seen() -> None:
+    conn = sqlite3.connect(":memory:")
+    ensure_schema(conn)
+
+    ts1 = 1_700_000_000_000
+    apply_snapshot(conn, ts_ms=ts1, symbols=["btc", "ETH", "ETH", "  sol  ", ""])
+
+    got1 = _listings(conn)
+    assert got1 == {
+        "BTC": (ts1, ts1),
+        "ETH": (ts1, ts1),
+        "SOL": (ts1, ts1),
+    }
+
+    ts2 = ts1 + 60_000
+    apply_snapshot(conn, ts_ms=ts2, symbols=["btc", "eth", "DOGE"])
+
+    got2 = _listings(conn)
+    assert got2 == {
+        "BTC": (ts1, ts2),
+        "DOGE": (ts2, ts2),
+        "ETH": (ts1, ts2),
+        "SOL": (ts1, ts1),
+    }
+
+
+def test_apply_snapshot_is_order_independent() -> None:
+    conn = sqlite3.connect(":memory:")
+    ensure_schema(conn)
+
+    ts1 = 1_700_000_000_000
+    ts2 = ts1 + 60_000
+
+    apply_snapshot(conn, ts_ms=ts2, symbols=["AAA"])
+    apply_snapshot(conn, ts_ms=ts1, symbols=["AAA"])
+
+    got = _listings(conn)
+    assert got == {"AAA": (ts1, ts2)}
+
+
+def test_apply_snapshot_is_idempotent_for_same_ts() -> None:
+    conn = sqlite3.connect(":memory:")
+    ensure_schema(conn)
+
+    ts = 1_700_000_000_000
+    apply_snapshot(conn, ts_ms=ts, symbols=["BTC", "ETH"])
+    apply_snapshot(conn, ts_ms=ts, symbols=["BTC", "ETH"])
+
+    (n_rows,) = conn.execute("SELECT COUNT(*) FROM universe_snapshots").fetchone()
+    assert int(n_rows) == 2

--- a/tools/sync_universe_history.py
+++ b/tools/sync_universe_history.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Sync Hyperliquid universe metadata to SQLite to track listings/delistings.
+
+This is intended to reduce survivorship bias in backtests by keeping a local record of
+when symbols appear and disappear from the Hyperliquid perp universe.
+
+The database lives alongside candle DBs by default:
+  - `candles_dbs/universe_history.db` (or `$AI_QUANT_CANDLES_DB_DIR/universe_history.db`)
+
+Schema:
+  - `universe_snapshots(ts_ms, symbol)` records each sync's universe membership.
+  - `universe_listings(symbol, first_seen_ms, last_seen_ms)` is derived incrementally.
+
+Notes:
+  - `first_seen_ms` / `last_seen_ms` reflect the first/last time *this script* observed
+    the symbol in the live universe. They are not guaranteed to be the exchange's true
+    listing/delisting timestamps.
+  - To make backtest filtering meaningful, run this script on a schedule (e.g. hourly).
+
+Usage:
+  uv run python tools/sync_universe_history.py
+  uv run python tools/sync_universe_history.py --db candles_dbs/universe_history.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+
+DB_SCHEMA = """
+CREATE TABLE IF NOT EXISTS universe_snapshots (
+    ts_ms INTEGER NOT NULL,
+    symbol TEXT NOT NULL,
+    PRIMARY KEY (ts_ms, symbol)
+);
+
+CREATE TABLE IF NOT EXISTS universe_listings (
+    symbol TEXT NOT NULL PRIMARY KEY,
+    first_seen_ms INTEGER NOT NULL,
+    last_seen_ms INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_universe_snapshots_symbol_ts
+    ON universe_snapshots (symbol, ts_ms);
+CREATE INDEX IF NOT EXISTS idx_universe_listings_first_last
+    ON universe_listings (first_seen_ms, last_seen_ms);
+"""
+
+
+def _default_db_path() -> Path:
+    raw_dir = str(os.getenv("AI_QUANT_CANDLES_DB_DIR", "") or "").strip()
+    if raw_dir:
+        return Path(raw_dir) / "universe_history.db"
+    return Path(__file__).resolve().parents[1] / "candles_dbs" / "universe_history.db"
+
+
+def _hl_timeout_s() -> float:
+    raw = os.getenv("AI_QUANT_HL_TIMEOUT_S", "10")
+    try:
+        v = float(raw)
+    except Exception:
+        v = 10.0
+    return float(max(0.5, min(30.0, v)))
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(DB_SCHEMA)
+    conn.commit()
+
+
+def normalise_symbols(symbols: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for s in symbols:
+        sym = str(s or "").strip().upper()
+        if not sym or sym in seen:
+            continue
+        seen.add(sym)
+        out.append(sym)
+    out.sort()
+    return out
+
+
+def apply_snapshot(conn: sqlite3.Connection, *, ts_ms: int, symbols: list[str]) -> None:
+    """Insert a snapshot and update derived listings (idempotent).
+
+    The derived table is updated with:
+      - first_seen_ms = min(existing, ts_ms)
+      - last_seen_ms  = max(existing, ts_ms)
+
+    This makes the operation safe even if snapshots arrive out of order.
+    """
+    ts_ms_i = int(ts_ms)
+    syms = normalise_symbols(symbols)
+    if not syms:
+        return
+
+    rows = [(ts_ms_i, s) for s in syms]
+    conn.executemany(
+        "INSERT OR IGNORE INTO universe_snapshots (ts_ms, symbol) VALUES (?, ?)",
+        rows,
+    )
+
+    conn.executemany(
+        """
+        INSERT INTO universe_listings (symbol, first_seen_ms, last_seen_ms)
+        VALUES (?, ?, ?)
+        ON CONFLICT(symbol) DO UPDATE SET
+            first_seen_ms = min(universe_listings.first_seen_ms, excluded.first_seen_ms),
+            last_seen_ms  = max(universe_listings.last_seen_ms,  excluded.last_seen_ms)
+        """,
+        [(s, ts_ms_i, ts_ms_i) for s in syms],
+    )
+    conn.commit()
+
+
+def fetch_hyperliquid_universe_symbols(*, timeout_s: float) -> list[str]:
+    """Fetch the current perp universe symbols from Hyperliquid."""
+    from hyperliquid.info import Info
+    from hyperliquid.utils import constants
+
+    info = Info(constants.MAINNET_API_URL, skip_ws=True, timeout=float(timeout_s))
+    data = info.meta_and_asset_ctxs()
+    if not data or len(data) < 1:
+        return []
+
+    meta = data[0] or {}
+    universe = meta.get("universe") or []
+    out: list[str] = []
+    for u in universe:
+        try:
+            out.append(str(u["name"]).upper())
+        except Exception:
+            continue
+    return normalise_symbols(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Sync Hyperliquid universe history to SQLite")
+    ap.add_argument(
+        "--db",
+        type=str,
+        default=str(_default_db_path()),
+        help="SQLite DB path (default: derived from AI_QUANT_CANDLES_DB_DIR or ./candles_dbs/universe_history.db)",
+    )
+    ap.add_argument(
+        "--ts-ms",
+        type=int,
+        default=0,
+        help="Override snapshot timestamp in milliseconds (default: now)",
+    )
+    ap.add_argument(
+        "--timeout-s",
+        type=float,
+        default=_hl_timeout_s(),
+        help="Hyperliquid REST timeout in seconds (default: AI_QUANT_HL_TIMEOUT_S or 10)",
+    )
+    args = ap.parse_args()
+
+    ts_ms = int(args.ts_ms) if int(args.ts_ms or 0) > 0 else int(time.time() * 1000)
+
+    db_path = Path(args.db).expanduser()
+    try:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        print(f"[universe] ERROR: cannot create DB directory: {db_path.parent} ({e})", file=sys.stderr)
+        return 2
+
+    try:
+        symbols = fetch_hyperliquid_universe_symbols(timeout_s=float(args.timeout_s))
+    except Exception as e:
+        print(f"[universe] ERROR: failed to fetch HL universe: {e}", file=sys.stderr)
+        return 3
+
+    if not symbols:
+        print("[universe] ERROR: fetched empty universe; refusing to write snapshot", file=sys.stderr)
+        return 4
+
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    try:
+        conn.execute("PRAGMA journal_mode = WAL;")
+        conn.execute("PRAGMA synchronous = NORMAL;")
+        ensure_schema(conn)
+
+        # Pre-read for simple counters
+        existing = {r[0] for r in conn.execute("SELECT symbol FROM universe_listings").fetchall()}
+        apply_snapshot(conn, ts_ms=ts_ms, symbols=symbols)
+
+        after = {r[0] for r in conn.execute("SELECT symbol FROM universe_listings").fetchall()}
+        new_syms = sorted(after - existing)
+        print(
+            f"[universe] Snapshot written: ts_ms={ts_ms}, symbols={len(symbols)}, new_symbols={len(new_syms)}, db={db_path}"
+        )
+        if new_syms:
+            sample = ", ".join(new_syms[:20])
+            suffix = " ..." if len(new_syms) > 20 else ""
+            print(f"[universe] New symbols: {sample}{suffix}")
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements universe change tracking to reduce survivorship bias in backtests.

Key changes:
- Add `tools/sync_universe_history.py` to snapshot the Hyperliquid perp universe into `candles_dbs/universe_history.db`.
- Add `--universe-filter` and `--universe-db` flags to `mei-backtester replay` and `mei-backtester sweep`.
- Update `backtester/README.md` and `docs/runbook.md` with usage.
- Add unit tests for universe snapshot derivation.

Tests:
- `uv run pytest -q`
- `cd backtester && cargo test -p bt-cli -p bt-data`

Closes #11
