### PR TITLE
fix(bt-core): derive Default on TradeRecord for forward-compat

### DIFF
--- a/backtester/crates/bt-core/src/config.rs
+++ b/backtester/crates/bt-core/src/config.rs
@@ -20,8 +20,9 @@ pub enum Signal {
 }
 
 /// Confidence tier for entry and add filters.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum Confidence {
+    #[default]
     Low = 0,
     Medium = 1,
     High = 2,

--- a/backtester/crates/bt-core/src/engine.rs
+++ b/backtester/crates/bt-core/src/engine.rs
@@ -536,6 +536,7 @@ pub fn run_simulation(
                     entry_atr: cand.atr,
                     leverage,
                     margin_used,
+                    ..Default::default()
                 });
             }
         }
@@ -748,6 +749,7 @@ pub fn run_simulation(
                                         entry_atr: pos.entry_atr,
                                         leverage: pos.leverage,
                                         margin_used: pos.margin_used,
+                                        ..Default::default()
                                     });
                                 }
                             }
@@ -1120,6 +1122,7 @@ fn apply_exit(
             entry_atr: pos.entry_atr,
             leverage: pos.leverage,
             margin_used: pos.margin_used * partial_pct,
+            ..Default::default()
         });
 
         // Reduce position in place
@@ -1166,6 +1169,7 @@ fn apply_exit(
             entry_atr: pos.entry_atr,
             leverage: pos.leverage,
             margin_used: pos.margin_used,
+            ..Default::default()
         });
 
         state.positions.remove(symbol);
@@ -1347,6 +1351,7 @@ fn try_pyramid(
         entry_atr: atr,
         leverage,
         margin_used: add_margin,
+        ..Default::default()
     });
 
     // Update position
@@ -1609,6 +1614,7 @@ fn execute_sub_bar_entry(
         entry_atr: atr,
         leverage,
         margin_used,
+        ..Default::default()
     });
 
     true

--- a/backtester/crates/bt-core/src/position.rs
+++ b/backtester/crates/bt-core/src/position.rs
@@ -121,7 +121,7 @@ impl Position {
 // Trade record (log entry for each trade action)
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TradeRecord {
     pub timestamp_ms: i64,
     pub symbol: String,


### PR DESCRIPTION
## Summary
- Derive `Default` on `TradeRecord` and `Confidence` so new fields don't break all 6 constructor sites in `engine.rs`
- All constructors now use `..Default::default()` to absorb future fields automatically
- 3 files, 9 lines added — zero behavior change

## Test plan
- [x] `cargo build --release` passes in clean worktree
- [x] `replay` backtest produces identical results to pre-change

🤖 Generated with [Claude Code](https://claude.com/claude-code)