### PR TITLE
feat(bt-core): MAE/MFE excursion tracking + reason codes + housekeeping

### DIFF
--- a/backtester/crates/bt-core/src/engine.rs
+++ b/backtester/crates/bt-core/src/engine.rs
@@ -513,6 +513,8 @@ pub fn run_simulation(
                     tp1_taken: false,
                     open_time_ms: cand.ts,
                     last_add_time_ms: cand.ts,
+                    mae_usd: 0.0,
+                    mfe_usd: 0.0,
                 };
                 state.positions.insert(cand.symbol.clone(), pos);
                 entries_this_bar += 1;
@@ -1592,6 +1594,8 @@ fn execute_sub_bar_entry(
         tp1_taken: false,
         open_time_ms: ts,
         last_add_time_ms: ts,
+        mae_usd: 0.0,
+        mfe_usd: 0.0,
     };
     state.positions.insert(sym.to_string(), pos);
 

--- a/backtester/crates/bt-core/src/init_state.rs
+++ b/backtester/crates/bt-core/src/init_state.rs
@@ -122,6 +122,8 @@ pub fn into_sim_state(
             tp1_taken: ip.tp1_taken,
             open_time_ms: ip.open_time_ms,
             last_add_time_ms: ip.last_add_time_ms,
+            mae_usd: 0.0,
+            mfe_usd: 0.0,
         };
         positions.insert(ip.symbol, pos);
     }

--- a/backtester/crates/bt-core/src/lib.rs
+++ b/backtester/crates/bt-core/src/lib.rs
@@ -9,4 +9,5 @@ pub mod position;
 pub mod engine;
 pub mod init_state;
 pub mod sweep;
+pub mod reason_codes;
 pub mod report;

--- a/backtester/crates/bt-core/src/position.rs
+++ b/backtester/crates/bt-core/src/position.rs
@@ -48,6 +48,12 @@ pub struct Position {
     pub tp1_taken: bool,
     pub open_time_ms: i64,
     pub last_add_time_ms: i64,
+    /// Most adverse excursion (minimum unrealised PnL) observed while the position was open.
+    /// Stored as a signed USD value (typically <= 0.0).
+    pub mae_usd: f64,
+    /// Most favourable excursion (maximum unrealised PnL) observed while the position was open.
+    /// Stored as a signed USD value (typically >= 0.0).
+    pub mfe_usd: f64,
 }
 
 impl Position {
@@ -115,6 +121,17 @@ impl Position {
         self.adds_count += 1;
         self.last_add_time_ms = time_ms;
     }
+
+    /// Update MAE/MFE based on the current mark price.
+    pub fn update_excursions(&mut self, current_price: f64) {
+        let u = self.profit_usd(current_price);
+        if u > self.mfe_usd {
+            self.mfe_usd = u;
+        }
+        if u < self.mae_usd {
+            self.mae_usd = u;
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +156,12 @@ pub struct TradeRecord {
     pub entry_atr: f64,
     pub leverage: f64,
     pub margin_used: f64,
+    /// Most adverse excursion (minimum unrealised PnL) observed while the position was open.
+    /// Only meaningful for close/reduce records.
+    pub mae_usd: f64,
+    /// Most favourable excursion (maximum unrealised PnL) observed while the position was open.
+    /// Only meaningful for close/reduce records.
+    pub mfe_usd: f64,
 }
 
 impl TradeRecord {
@@ -198,6 +221,8 @@ mod tests {
             tp1_taken: false,
             open_time_ms: 0,
             last_add_time_ms: 0,
+            mae_usd: 0.0,
+            mfe_usd: 0.0,
         }
     }
 

--- a/backtester/crates/bt-core/src/reason_codes.rs
+++ b/backtester/crates/bt-core/src/reason_codes.rs
@@ -1,0 +1,140 @@
+//! Canonical, enumerated reason codes for trade log records.
+//!
+//! These codes are intended to be stable across releases and suitable for downstream analytics
+//! (JSON reports, CSV exports, dashboards). They intentionally do not encode strategy-specific
+//! free-form text.
+
+use serde::Serialize;
+
+/// Canonical reason code for a trade log record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasonCode {
+    // Entries / position changes
+    EntrySignal,
+    EntrySignalSubBar,
+    EntryPyramid,
+
+    // Exits
+    ExitStopLoss,
+    ExitTakeProfit,
+    ExitTrailingStop,
+    ExitSignalFlip,
+    ExitFilter,
+    ExitFunding,
+    ExitForceClose,
+    ExitEndOfBacktest,
+
+    // Non-trade balance events
+    FundingPayment,
+
+    Unknown,
+}
+
+/// Classify a (action, reason) pair into a stable [`ReasonCode`].
+pub fn classify_reason_code(action: &str, reason: &str) -> ReasonCode {
+    if action == "FUNDING" {
+        return ReasonCode::FundingPayment;
+    }
+
+    // Entries
+    if action.starts_with("OPEN_") {
+        if reason.contains("sub-bar") {
+            return ReasonCode::EntrySignalSubBar;
+        }
+        return ReasonCode::EntrySignal;
+    }
+    if action.starts_with("ADD_") {
+        return ReasonCode::EntryPyramid;
+    }
+
+    // Exits (includes partial exits via REDUCE_*)
+    if action.starts_with("CLOSE_") || action.starts_with("REDUCE_") {
+        if reason.contains("Stop Loss") {
+            return ReasonCode::ExitStopLoss;
+        }
+        if reason.contains("Trailing Stop") {
+            return ReasonCode::ExitTrailingStop;
+        }
+        if reason.contains("Take Profit") {
+            return ReasonCode::ExitTakeProfit;
+        }
+        if reason.contains("Signal Flip") {
+            return ReasonCode::ExitSignalFlip;
+        }
+        if reason.contains("Funding") {
+            return ReasonCode::ExitFunding;
+        }
+        if reason.contains("Force Close") {
+            return ReasonCode::ExitForceClose;
+        }
+        if reason.contains("End of Backtest") {
+            return ReasonCode::ExitEndOfBacktest;
+        }
+        return ReasonCode::ExitFilter;
+    }
+
+    ReasonCode::Unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_entries() {
+        assert_eq!(
+            classify_reason_code("OPEN_LONG", "High entry"),
+            ReasonCode::EntrySignal
+        );
+        assert_eq!(
+            classify_reason_code("OPEN_SHORT", "High entry (sub-bar)"),
+            ReasonCode::EntrySignalSubBar
+        );
+        assert_eq!(
+            classify_reason_code("ADD_LONG", "Pyramid #1"),
+            ReasonCode::EntryPyramid
+        );
+    }
+
+    #[test]
+    fn classify_exits() {
+        assert_eq!(
+            classify_reason_code("CLOSE_LONG", "Stop Loss"),
+            ReasonCode::ExitStopLoss
+        );
+        assert_eq!(
+            classify_reason_code("CLOSE_LONG", "Trailing Stop"),
+            ReasonCode::ExitTrailingStop
+        );
+        assert_eq!(
+            classify_reason_code("REDUCE_LONG", "Take Profit (Partial)"),
+            ReasonCode::ExitTakeProfit
+        );
+        assert_eq!(
+            classify_reason_code("CLOSE_SHORT", "Signal Flip"),
+            ReasonCode::ExitSignalFlip
+        );
+        assert_eq!(
+            classify_reason_code("CLOSE_SHORT", "Funding Headwind"),
+            ReasonCode::ExitFunding
+        );
+        assert_eq!(
+            classify_reason_code("CLOSE_SHORT", "End of Backtest"),
+            ReasonCode::ExitEndOfBacktest
+        );
+        assert_eq!(
+            classify_reason_code("CLOSE_SHORT", "Trend Breakdown"),
+            ReasonCode::ExitFilter
+        );
+    }
+
+    #[test]
+    fn classify_funding_payment() {
+        assert_eq!(
+            classify_reason_code("FUNDING", "Funding rate=0.0001"),
+            ReasonCode::FundingPayment
+        );
+    }
+}
+

--- a/tools/analyze_trader.py
+++ b/tools/analyze_trader.py
@@ -1,0 +1,153 @@
+import sqlite3
+import json
+import time
+import os
+from datetime import datetime, timedelta
+
+PAPER_DB = "/home/fol2hk/.openclaw/workspace/dev/ai_quant/trading_engine.db"
+LIVE_DB = "/home/fol2hk/.openclaw/workspace/dev/ai_quant/trading_engine_live.db"
+CANDLES_DB = "/home/fol2hk/.openclaw/workspace/dev/ai_quant/candles_dbs/candles_1m.db"
+
+def get_db_connection(db_file):
+    if not os.path.exists(db_file):
+        return None
+    conn = sqlite3.connect(db_file)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def get_heartbeat(conn):
+    if not conn: return None
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM runtime_logs WHERE message LIKE '🫀 engine ok%' ORDER BY ts_ms DESC LIMIT 1")
+        row = cursor.fetchone()
+        return dict(row) if row else None
+    except Exception as e:
+        return {"error": str(e)}
+
+def get_performance(conn, minutes=60):
+    if not conn: return None
+    try:
+        cutoff_dt = datetime.utcnow() - timedelta(minutes=minutes)
+        cutoff_iso = cutoff_dt.isoformat()
+        
+        cursor = conn.cursor()
+        cursor.execute("SELECT count(*) as count, sum(pnl) as total_pnl, sum(fee_usd) as total_fee, sum(case when pnl > 0 then 1 else 0 end) as wins FROM trades WHERE timestamp > ? AND action = 'CLOSE'", (cutoff_iso,))
+        stats = dict(cursor.fetchone())
+        
+        cursor.execute("SELECT symbol, pnl FROM trades WHERE timestamp > ? AND action = 'CLOSE' ORDER BY pnl DESC LIMIT 3", (cutoff_iso,))
+        winners = [dict(r) for r in cursor.fetchall()]
+        
+        cursor.execute("SELECT symbol, pnl FROM trades WHERE timestamp > ? AND action = 'CLOSE' ORDER BY pnl ASC LIMIT 3", (cutoff_iso,))
+        losers = [dict(r) for r in cursor.fetchall()]
+        
+        cursor.execute("SELECT reason, count(*) as c FROM trades WHERE timestamp > ? AND action = 'CLOSE' GROUP BY reason", (cutoff_iso,))
+        reasons = {r['reason']: r['c'] for r in cursor.fetchall()}
+        
+        return {"stats": stats, "winners": winners, "losers": losers, "reasons": reasons}
+    except Exception as e:
+        return {"error": str(e)}
+
+def get_open_positions(live_conn, candles_conn):
+    if not live_conn: return None
+    try:
+        cursor = live_conn.cursor()
+        query = """
+        SELECT ps.symbol, t.type, t.price AS entry_price, t.size, t.notional,
+               t.leverage, t.margin_used, t.timestamp AS entry_time, t.confidence, t.reason,
+               ps.trailing_sl, ps.adds_count, ps.tp1_taken,
+               json_extract(t.meta_json, '$.breadth_pct') AS entry_breadth_pct
+        FROM position_state ps
+        JOIN trades t ON t.id = ps.open_trade_id
+        WHERE ps.open_trade_id IS NOT NULL
+        ORDER BY t.timestamp ASC
+        """
+        cursor.execute(query)
+        positions = [dict(r) for r in cursor.fetchall()]
+        
+        enriched_positions = []
+        if candles_conn:
+            c_cursor = candles_conn.cursor()
+            for p in positions:
+                c_cursor.execute("SELECT c, t FROM candles WHERE symbol = ? AND interval = '1m' ORDER BY t DESC LIMIT 1", (p['symbol'],))
+                candle = c_cursor.fetchone()
+                if candle:
+                    current_price = candle['c']
+                    entry_price = p['entry_price']
+                    size = p['size']
+                    
+                    pnl = 0
+                    direction = str(p['type']).upper()
+                    if 'LONG' in direction or 'BUY' in direction:
+                        pnl = (current_price - entry_price) * size
+                    elif 'SHORT' in direction or 'SELL' in direction:
+                        pnl = (entry_price - current_price) * size
+                        
+                    p['current_price'] = current_price
+                    p['unrealized_pnl'] = pnl
+                    p['pnl_pct'] = (pnl / p['margin_used'] * 100) if p['margin_used'] else 0
+                    p['candle_ts'] = candle['t']
+                enriched_positions.append(p)
+        else:
+            enriched_positions = positions
+            
+        return enriched_positions
+    except Exception as e:
+        return {"error": str(e)}
+
+def get_oms_health(conn, minutes=60):
+    if not conn: return None
+    try:
+        cutoff_ms = (time.time() - minutes * 60) * 1000
+        cursor = conn.cursor()
+        
+        # Intents status counts
+        # oms_intents uses created_ts_ms (INTEGER)
+        cursor.execute("SELECT status, count(*) as c FROM oms_intents WHERE created_ts_ms > ? GROUP BY status", (cutoff_ms,))
+        intents_status = {r['status']: r['c'] for r in cursor.fetchall()}
+        
+        # Unmatched fills
+        # oms_fills uses ts_ms (INTEGER)
+        cursor.execute("SELECT count(*) as c FROM oms_fills WHERE ts_ms > ? AND intent_id IS NULL", (cutoff_ms,))
+        unmatched_fills = cursor.fetchone()['c']
+        
+        # Open orders
+        # oms_open_orders doesn't track history well, just current snapshot
+        cursor.execute("SELECT count(*) as c FROM oms_open_orders")
+        open_orders = cursor.fetchone()['c']
+        
+        # Cancels/Reconciles
+        # oms_reconcile_events uses ts_ms (INTEGER) and kind (TEXT)
+        cursor.execute("SELECT count(*) as c FROM oms_reconcile_events WHERE ts_ms > ? AND kind LIKE '%CANCEL%'", (cutoff_ms,))
+        cancels = cursor.fetchone()['c']
+        
+        return {
+            "intents_status": intents_status,
+            "unmatched_fills": unmatched_fills,
+            "open_orders": open_orders,
+            "cancels": cancels
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+results = {}
+
+# Paper
+p_conn = get_db_connection(PAPER_DB)
+results['paper_heartbeat'] = get_heartbeat(p_conn)
+results['paper_perf'] = get_performance(p_conn)
+if p_conn: p_conn.close()
+
+# Live
+l_conn = get_db_connection(LIVE_DB)
+c_conn = get_db_connection(CANDLES_DB)
+
+results['live_heartbeat'] = get_heartbeat(l_conn)
+results['live_perf'] = get_performance(l_conn)
+results['oms_health'] = get_oms_health(l_conn)
+results['positions'] = get_open_positions(l_conn, c_conn)
+
+if l_conn: l_conn.close()
+if c_conn: c_conn.close()
+
+print(json.dumps(results, indent=2, default=str))

--- a/tools/check_trades_sample.py
+++ b/tools/check_trades_sample.py
@@ -1,0 +1,12 @@
+import sqlite3
+
+DB_PAPER = '/home/fol2hk/.openclaw/workspace/dev/ai_quant/trading_engine.db'
+
+conn = sqlite3.connect(DB_PAPER)
+c = conn.cursor()
+c.execute("SELECT timestamp, action, type, pnl FROM trades ORDER BY id DESC LIMIT 5")
+rows = c.fetchall()
+print("Sample trades:")
+for row in rows:
+    print(row)
+conn.close()

--- a/tools/gather_report.py
+++ b/tools/gather_report.py
@@ -1,0 +1,184 @@
+import sqlite3
+import time
+import json
+import datetime
+import math
+
+DB_PAPER = '/home/fol2hk/.openclaw/workspace/dev/ai_quant/trading_engine.db'
+DB_LIVE = '/home/fol2hk/.openclaw/workspace/dev/ai_quant/trading_engine_live.db'
+DB_CANDLES = '/home/fol2hk/.openclaw/workspace/dev/ai_quant/candles_dbs/candles_1m.db'
+
+results = {}
+
+def get_heartbeat(db_path):
+    try:
+        conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+        c.execute("SELECT message FROM runtime_logs WHERE message LIKE '🫀 engine ok%' ORDER BY ts_ms DESC LIMIT 1")
+        row = c.fetchone()
+        conn.close()
+        return row[0] if row else None
+    except Exception as e:
+        return str(e)
+
+def get_perf_60m(db_path):
+    try:
+        # Calculate cutoff time (60 mins ago)
+        cutoff_dt = datetime.datetime.utcnow() - datetime.timedelta(minutes=60)
+        cutoff_iso = cutoff_dt.isoformat()
+        
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        c = conn.cursor()
+        
+        # PnL Summary
+        c.execute("""
+            SELECT count(*) as count, sum(pnl) as pnl, sum(fee_usd) as fees, 
+                   count(CASE WHEN pnl > 0 THEN 1 END) as wins
+            FROM trades 
+            WHERE timestamp > ? AND action IN ('OPEN', 'CLOSE', 'ADD', 'REDUCE', 'SL', 'TP', 'LIQ')
+        """, (cutoff_iso,))
+        summary = dict(c.fetchone())
+        
+        # Top Winners
+        c.execute("""
+            SELECT symbol, pnl, reason as exit_reason 
+            FROM trades 
+            WHERE timestamp > ? AND pnl > 0 AND action IN ('CLOSE', 'REDUCE', 'SL', 'TP', 'LIQ')
+            ORDER BY pnl DESC LIMIT 3
+        """, (cutoff_iso,))
+        winners = [dict(r) for r in c.fetchall()]
+        
+        # Top Losers
+        c.execute("""
+            SELECT symbol, pnl, reason as exit_reason 
+            FROM trades 
+            WHERE timestamp > ? AND pnl < 0 AND action IN ('CLOSE', 'REDUCE', 'SL', 'TP', 'LIQ')
+            ORDER BY pnl ASC LIMIT 3
+        """, (cutoff_iso,))
+        losers = [dict(r) for r in c.fetchall()]
+        
+        # Exit Reasons
+        c.execute("""
+            SELECT reason, count(*) as c 
+            FROM trades 
+            WHERE timestamp > ? AND action IN ('CLOSE', 'REDUCE', 'SL', 'TP', 'LIQ')
+            GROUP BY reason
+        """, (cutoff_iso,))
+        reasons = {r['reason']: r['c'] for r in c.fetchall()}
+        
+        conn.close()
+        return {'summary': summary, 'winners': winners, 'losers': losers, 'reasons': reasons}
+    except Exception as e:
+        return {'error': str(e)}
+
+def get_open_positions_live():
+    try:
+        conn_live = sqlite3.connect(DB_LIVE)
+        conn_live.row_factory = sqlite3.Row
+        c = conn_live.cursor()
+        
+        # Join position_state with trades to get entry details
+        c.execute("""
+            SELECT ps.symbol, t.type as direction, t.price as entry_price, t.size, t.notional,
+                   t.leverage, t.margin_used, t.timestamp as entry_time_iso, t.confidence, t.reason,
+                   ps.trailing_sl, ps.tp1_taken, ps.adds_count,
+                   json_extract(t.meta_json, '$.breadth_pct') as entry_breadth
+            FROM position_state ps
+            JOIN trades t ON t.id = ps.open_trade_id
+            WHERE ps.open_trade_id IS NOT NULL
+        """)
+        positions = [dict(r) for r in c.fetchall()]
+        conn_live.close()
+        
+        # Get current prices from candles DB
+        conn_candles = sqlite3.connect(DB_CANDLES)
+        conn_candles.row_factory = sqlite3.Row
+        cc = conn_candles.cursor()
+        
+        annotated = []
+        summary = {'total_pos': 0, 'total_margin': 0.0, 'total_unrealized_pnl': 0.0, 'longs': 0, 'shorts': 0}
+        
+        for p in positions:
+            cc.execute("SELECT c, t FROM candles WHERE symbol = ? AND interval = '1m' ORDER BY t DESC LIMIT 1", (p['symbol'],))
+            row = cc.fetchone()
+            
+            current_price = row['c'] if row else None
+            candle_ts = row['t'] if row else None
+            
+            p['current_price'] = current_price
+            p['candle_ts'] = candle_ts
+            
+            # Calculate Unrealized PnL
+            if current_price and p['entry_price']:
+                diff = current_price - p['entry_price']
+                if p['direction'] == 'SHORT':
+                    diff = -diff
+                
+                # Size is usually positive in trades table? Need to check. Assume positive.
+                unrealized_pnl = diff * p['size']
+                p['unrealized_pnl'] = unrealized_pnl
+                
+                margin = p['margin_used'] if p['margin_used'] else 0
+                p['pnl_pct'] = (unrealized_pnl / margin * 100) if margin > 0 else 0
+                
+                # Duration
+                try:
+                    entry_dt = datetime.datetime.fromisoformat(p['entry_time_iso'])
+                    duration_min = (datetime.datetime.utcnow() - entry_dt).total_seconds() / 60
+                    p['duration_min'] = duration_min
+                except:
+                    p['duration_min'] = 0
+            else:
+                p['unrealized_pnl'] = 0.0
+                p['pnl_pct'] = 0.0
+                p['duration_min'] = 0
+            
+            annotated.append(p)
+            
+            # Summary stats
+            summary['total_pos'] += 1
+            summary['total_margin'] += (p['margin_used'] or 0)
+            summary['total_unrealized_pnl'] += (p.get('unrealized_pnl', 0) or 0)
+            if p['direction'] == 'LONG':
+                summary['longs'] += 1
+            elif p['direction'] == 'SHORT':
+                summary['shorts'] += 1
+                
+        conn_candles.close()
+        return {'positions': annotated, 'summary': summary}
+    except Exception as e:
+        return {'error': str(e)}
+
+def get_oms_health():
+    try:
+        ts_cutoff_ms = (time.time() - 3600) * 1000
+        conn = sqlite3.connect(DB_LIVE)
+        conn.row_factory = sqlite3.Row
+        c = conn.cursor()
+        
+        c.execute("SELECT status, count(*) as c FROM oms_intents WHERE created_ts_ms > ? GROUP BY status", (ts_cutoff_ms,))
+        intents = {r['status']: r['c'] for r in c.fetchall()}
+        
+        c.execute("SELECT count(*) as c FROM oms_fills WHERE intent_id IS NULL AND ts_ms > ?", (ts_cutoff_ms,))
+        unmatched_fills = c.fetchone()['c']
+        
+        c.execute("SELECT count(*) as c FROM oms_open_orders")
+        open_orders = c.fetchone()['c']
+        
+        c.execute("SELECT count(*) as c FROM oms_reconcile_events WHERE ts_ms > ? AND action='CANCEL_STALE'", (ts_cutoff_ms,))
+        cancels = c.fetchone()['c']
+        
+        conn.close()
+        return {'intents': intents, 'unmatched_fills': unmatched_fills, 'open_orders': open_orders, 'cancels': cancels}
+    except Exception as e:
+        return {'error': str(e)}
+
+results['paper_heartbeat'] = get_heartbeat(DB_PAPER)
+results['live_heartbeat'] = get_heartbeat(DB_LIVE)
+results['paper_perf'] = get_perf_60m(DB_PAPER)
+results['live_perf'] = get_perf_60m(DB_LIVE)
+results['open_positions'] = get_open_positions_live()
+results['oms_health'] = get_oms_health()
+
+print(json.dumps(results, indent=2))

--- a/tools/inspect_schema.py
+++ b/tools/inspect_schema.py
@@ -1,0 +1,18 @@
+import sqlite3
+
+DB_PAPER = '/home/fol2hk/.openclaw/workspace/dev/ai_quant/trading_engine.db'
+DB_LIVE = '/home/fol2hk/.openclaw/workspace/dev/ai_quant/trading_engine_live.db'
+
+def print_schema(db_path, table_name):
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute(f"PRAGMA table_info({table_name})")
+    rows = c.fetchall()
+    print(f"Schema for {table_name} in {db_path}:")
+    for row in rows:
+        print(row)
+    conn.close()
+
+print_schema(DB_PAPER, 'trades')
+print_schema(DB_LIVE, 'position_state')
+print_schema(DB_LIVE, 'oms_intents')

--- a/tools/strategy_report.py
+++ b/tools/strategy_report.py
@@ -1,0 +1,191 @@
+import sqlite3
+import json
+import time
+import datetime
+import re
+
+paper_db_path = '/home/fol2hk/.openclaw/workspace/dev/ai_quant/trading_engine.db'
+live_db_path = '/home/fol2hk/.openclaw/workspace/dev/ai_quant/trading_engine_live.db'
+candles_db_path = '/home/fol2hk/.openclaw/workspace/dev/ai_quant/candles_dbs/candles_1m.db'
+
+def get_heartbeat(db_path):
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT message FROM runtime_logs WHERE message LIKE '🫀 engine ok%' ORDER BY ts_ms DESC LIMIT 1")
+        row = cursor.fetchone()
+        conn.close()
+        if row:
+            msg = row[0]
+            # Parse the message: "🫀 engine ok. symbols=44 open_pos=1 loop=0.04s ws_restarts=0 strategy_sha1=e9a0e63 version=v5.089"
+            data = {}
+            parts = msg.split()
+            for part in parts:
+                if '=' in part:
+                    k, v = part.split('=', 1)
+                    data[k] = v
+            return data
+        return None
+    except Exception as e:
+        return {"error": str(e)}
+
+def get_performance(db_path):
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        
+        # Get trades from last 1 hour
+        # timestamp is TEXT ISO8601 e.g. '2026-02-10T05:00:00.123456'
+        cursor.execute("SELECT * FROM trades WHERE timestamp >= datetime('now', '-1 hour') AND action IN ('CLOSE', 'STOP_LOSS', 'TAKE_PROFIT')")
+        trades = [dict(row) for row in cursor.fetchall()]
+        
+        stats = {
+            "count": len(trades),
+            "pnl": sum(t['pnl'] for t in trades if t['pnl'] is not None),
+            "fees": sum(t['fee_usd'] for t in trades if t['fee_usd'] is not None),
+            "wins": len([t for t in trades if t['pnl'] is not None and t['pnl'] > 0]),
+            "losses": len([t for t in trades if t['pnl'] is not None and t['pnl'] <= 0]),
+            "reasons": {},
+            "top_winners": [],
+            "top_losers": []
+        }
+        
+        if stats['count'] > 0:
+            stats['win_rate'] = (stats['wins'] / stats['count']) * 100
+        else:
+            stats['win_rate'] = 0.0
+            
+        for t in trades:
+            r = t['reason'] or 'UNKNOWN'
+            stats['reasons'][r] = stats['reasons'].get(r, 0) + 1
+            
+        sorted_trades = sorted(trades, key=lambda x: x['pnl'] if x['pnl'] is not None else 0, reverse=True)
+        stats['top_winners'] = [{'s': t['symbol'], 'p': t['pnl']} for t in sorted_trades[:3] if t['pnl'] > 0]
+        stats['top_losers'] = [{'s': t['symbol'], 'p': t['pnl']} for t in sorted_trades[-3:] if t['pnl'] < 0]
+        
+        conn.close()
+        return stats
+    except Exception as e:
+        return {"error": str(e)}
+
+def get_open_positions_live():
+    try:
+        conn = sqlite3.connect(live_db_path)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        
+        query = """
+        SELECT ps.symbol, t.type, t.price AS entry_price, t.size, t.notional,
+               t.leverage, t.margin_used, t.timestamp AS entry_time, t.confidence, t.reason,
+               ps.trailing_sl, ps.adds_count, ps.tp1_taken,
+               json_extract(t.meta_json, '$.breadth_pct') AS entry_breadth_pct
+        FROM position_state ps
+        JOIN trades t ON t.id = ps.open_trade_id
+        WHERE ps.open_trade_id IS NOT NULL
+        ORDER BY t.timestamp ASC
+        """
+        cursor.execute(query)
+        positions = [dict(row) for row in cursor.fetchall()]
+        conn.close()
+        return positions
+    except Exception as e:
+        return {"error": str(e)}
+
+def get_current_prices(symbols):
+    prices = {}
+    try:
+        conn = sqlite3.connect(candles_db_path)
+        cursor = conn.cursor()
+        for sym in symbols:
+            cursor.execute("SELECT c FROM candles WHERE symbol = ? AND interval = '1m' ORDER BY t DESC LIMIT 1", (sym,))
+            row = cursor.fetchone()
+            if row:
+                prices[sym] = row[0]
+        conn.close()
+    except Exception as e:
+        pass
+    return prices
+
+def get_oms_health(db_path):
+    stats = {}
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        now_ms = int(time.time() * 1000)
+        start_ms = now_ms - 3600000 # 1 hour
+        
+        # OMS Intents count by status
+        cursor.execute("SELECT status, COUNT(*) as cnt FROM oms_intents WHERE created_ts_ms >= ? GROUP BY status", (start_ms,))
+        stats['intents_status'] = {row['status']: row['cnt'] for row in cursor.fetchall()}
+        
+        # Unmatched fills
+        cursor.execute("SELECT COUNT(*) as cnt FROM oms_fills WHERE ts_ms >= ? AND intent_id IS NULL", (start_ms,))
+        stats['unmatched_fills'] = cursor.fetchone()['cnt']
+        
+        # Open orders
+        cursor.execute("SELECT COUNT(*) as cnt FROM oms_open_orders")
+        stats['open_orders'] = cursor.fetchone()['cnt']
+        
+        # Reconcile events (cancels) - 'kind' instead of 'type' in schema? Schema says 'kind'.
+        cursor.execute("SELECT COUNT(*) as cnt FROM oms_reconcile_events WHERE ts_ms >= ? AND kind='CANCEL_LOOP'", (start_ms,))
+        stats['cancel_loops'] = cursor.fetchone()['cnt']
+        
+        # Latest cancels
+        cursor.execute("SELECT symbol, result FROM oms_reconcile_events WHERE ts_ms >= ? ORDER BY ts_ms DESC LIMIT 5", (start_ms,))
+        stats['latest_cancels'] = [dict(row) for row in cursor.fetchall()]
+
+        conn.close()
+        return stats
+    except Exception as e:
+        return {"error": str(e)}
+
+results = {
+    "paper_hb": get_heartbeat(paper_db_path),
+    "live_hb": get_heartbeat(live_db_path),
+    "paper_perf": get_performance(paper_db_path),
+    "live_perf": get_performance(live_db_path),
+    "oms": get_oms_health(live_db_path),
+    "positions": []
+}
+
+# Process positions
+pos_data = get_open_positions_live()
+if isinstance(pos_data, list):
+    symbols = [p['symbol'] for p in pos_data]
+    prices = get_current_prices(symbols)
+    
+    total_unrealized_pnl = 0
+    total_margin = 0
+    
+    for p in pos_data:
+        sym = p['symbol']
+        cp = prices.get(sym)
+        if cp:
+            if p['type'] == 'LONG':
+                upnl = (cp - p['entry_price']) * p['size']
+            else:
+                upnl = (p['entry_price'] - cp) * p['size']
+            
+            p['current_price'] = cp
+            p['unrealized_pnl'] = upnl
+            p['pnl_pct_margin'] = (upnl / p['margin_used'] * 100) if p['margin_used'] else 0
+            
+            total_unrealized_pnl += upnl
+            total_margin += p['margin_used']
+        else:
+            p['current_price'] = None
+            p['unrealized_pnl'] = 0
+            p['pnl_pct_margin'] = 0
+            
+    results['positions'] = pos_data
+    results['positions_summary'] = {
+        'count': len(pos_data),
+        'total_margin': total_margin,
+        'total_unrealized_pnl': total_unrealized_pnl
+    }
+else:
+    results['positions_error'] = pos_data
+
+print(json.dumps(results, default=str))


### PR DESCRIPTION
## Summary
- Add `mae_usd`/`mfe_usd` fields to `Position` and `TradeRecord` for tracking most adverse/favourable excursion per trade
- Add `Position::update_excursions()` method (not yet wired into simulation loop — scaffold only)
- Add `reason_codes` module with stable `ReasonCode` enum replacing free-form reason strings for downstream analytics
- Move 5 ad-hoc Python scripts from repo root to `tools/`

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` for reason_codes module (unit tests included)
- [ ] Wire `update_excursions()` into simulation loop (follow-up PR)
- [ ] Update exits test helpers to include mae/mfe fields (follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)