### PR TITLE
Fix bt-cli duplicate test module on major-v8

### DIFF
--- a/backtester/crates/bt-cli/src/main.rs
+++ b/backtester/crates/bt-cli/src/main.rs
@@ -2277,7 +2277,7 @@ fn print_summary(r: &bt_core::report::SimReport, initial_balance: f64) {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
+mod guardrails_tests {
     use super::*;
 
     #[test]


### PR DESCRIPTION
This fixes a Rust compile error on `major-v8` (E0428: duplicate `mod tests` in `bt-cli` main.rs) introduced by merging AQC-402.

Change:
- Rename the guardrails test module to avoid clashing with the existing replay/export test module.

Verification:
- `python3 -m pytest -q`
- `cd backtester && cargo test -q`
- `cd ws_sidecar && cargo test -q`