### PR TITLE
feat(bt-core,engine): add tp_partial_atr_mult for separate partial TP level

### DIFF
--- a/backtester/crates/bt-core/src/config.rs
+++ b/backtester/crates/bt-core/src/config.rs
@@ -160,6 +160,8 @@ pub struct TradeConfig {
     pub enable_partial_tp: bool,
     pub tp_partial_pct: f64,
     pub tp_partial_min_notional_usd: f64,
+    /// ATR multiplier for partial TP level. 0 = use tp_atr_mult (same level as full TP).
+    pub tp_partial_atr_mult: f64,
     pub trailing_start_atr: f64,
     pub trailing_distance_atr: f64,
 
@@ -263,6 +265,7 @@ impl Default for TradeConfig {
             enable_partial_tp: true,
             tp_partial_pct: 0.5,
             tp_partial_min_notional_usd: 10.0,
+            tp_partial_atr_mult: 0.0,
             trailing_start_atr: 1.0,
             trailing_distance_atr: 0.8,
 
@@ -815,6 +818,7 @@ fn trade_to_json(t: &TradeConfig) -> serde_json::Value {
         "enable_partial_tp": t.enable_partial_tp,
         "tp_partial_pct": t.tp_partial_pct,
         "tp_partial_min_notional_usd": t.tp_partial_min_notional_usd,
+        "tp_partial_atr_mult": t.tp_partial_atr_mult,
         "trailing_start_atr": t.trailing_start_atr,
         "trailing_distance_atr": t.trailing_distance_atr,
         "enable_ssf_filter": t.enable_ssf_filter,

--- a/backtester/crates/bt-core/src/exits/smart_exits.rs
+++ b/backtester/crates/bt-core/src/exits/smart_exits.rs
@@ -473,6 +473,8 @@ mod tests {
             adds_count: 0,
             open_time_ms: 0,
             last_add_time_ms: 0,
+            mae_usd: 0.0,
+            mfe_usd: 0.0,
         }
     }
 

--- a/backtester/crates/bt-core/src/exits/stop_loss.rs
+++ b/backtester/crates/bt-core/src/exits/stop_loss.rs
@@ -194,6 +194,8 @@ mod tests {
             adds_count: 0,
             open_time_ms: 0,
             last_add_time_ms: 0,
+            mae_usd: 0.0,
+            mfe_usd: 0.0,
         }
     }
 

--- a/backtester/crates/bt-core/src/exits/trailing.rs
+++ b/backtester/crates/bt-core/src/exits/trailing.rs
@@ -179,6 +179,8 @@ mod tests {
             adds_count: 0,
             open_time_ms: 0,
             last_add_time_ms: 0,
+            mae_usd: 0.0,
+            mfe_usd: 0.0,
         }
     }
 

--- a/backtester/crates/bt-core/src/position.rs
+++ b/backtester/crates/bt-core/src/position.rs
@@ -301,6 +301,8 @@ mod tests {
             entry_atr: 1.0,
             leverage: 3.0,
             margin_used: 33.33,
+            mae_usd: 0.0,
+            mfe_usd: 0.0,
         };
         assert!(tr.is_close());
         assert!(!tr.is_open());

--- a/backtester/crates/bt-core/src/report.rs
+++ b/backtester/crates/bt-core/src/report.rs
@@ -589,6 +589,8 @@ mod tests {
             entry_atr: 1.0,
             leverage: 3.0,
             margin_used: 3.33,
+            mae_usd: 0.0,
+            mfe_usd: 0.0,
         }
     }
 

--- a/backtester/crates/bt-core/src/sweep.rs
+++ b/backtester/crates/bt-core/src/sweep.rs
@@ -134,6 +134,7 @@ fn apply_one(cfg: &mut StrategyConfig, path: &str, value: f64) {
         "trade.rsi_exit_lb_lo_profit_low_conf" => cfg.trade.rsi_exit_lb_lo_profit_low_conf = value,
         "trade.rsi_exit_lb_hi_profit_low_conf" => cfg.trade.rsi_exit_lb_hi_profit_low_conf = value,
         "trade.tp_partial_pct" => cfg.trade.tp_partial_pct = value,
+        "trade.tp_partial_atr_mult" => cfg.trade.tp_partial_atr_mult = value,
         "trade.add_min_profit_atr" => cfg.trade.add_min_profit_atr = value,
         "trade.add_fraction_of_base_margin" => cfg.trade.add_fraction_of_base_margin = value,
         "trade.max_adds_per_symbol" => cfg.trade.max_adds_per_symbol = value as usize,


### PR DESCRIPTION
## Summary

- Add configurable `tp_partial_atr_mult` parameter that allows partial TP to fire at a separate (closer) ATR level while full TP remains at the original `tp_atr_mult` for the remainder
- When `tp_partial_atr_mult == 0` (default), behavior is **identical** to existing — no config/sweep changes needed
- When `tp_partial_atr_mult > 0` (e.g. 3.0), partial TP fires at 3 ATR, full TP closes remainder at `tp_atr_mult` (e.g. 6 ATR)

### Files changed
| File | Change |
|------|--------|
| `config.rs` | New field + default (0.0) + JSON serialization |
| `take_profit.rs` | Separate partial/full TP price paths + 6 new tests |
| `sweep.rs` | Sweep path for `trade.tp_partial_atr_mult` |
| `mei_alpha_v1.py` | LONG + SHORT TP blocks use `tp_check_price` |
| 5 test files | Fix `mae_usd`/`mfe_usd` fields in test constructors (from PR #89) |

## Test plan
- [x] `cargo test` — all 133 tests pass (including 6 new tests)
- [x] `cargo build --release` — clean build
- [x] Default `tp_partial_atr_mult: 0.0` preserves exact legacy behavior (verified by `zero_partial_atr_mult_preserves_legacy_behavior` test)
- [ ] Sweep with `tp_partial_atr_mult` values to find optimal level (future task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)