### PR TITLE
AQC-601: standardised artifacts directory layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ cargo build --release -p bt-cli --features gpu
 
 See [backtester/README.md](backtester/README.md) for detailed documentation.
 
+## Strategy Factory Artifacts
+
+`factory_run.py` writes all outputs under the artifacts root directory (default: `artifacts/`) using a date-scoped layout:
+
+```
+artifacts/
+  YYYY-MM-DD/
+    run_<run_id>/
+      data_checks/
+      sweeps/
+      configs/
+      replays/
+      reports/
+      logs/
+      run_metadata.json
+```
+
+This layout is designed for reproducibility. A run directory should be self-contained: you can inspect the inputs, commands, and outputs without guessing what was executed.
+
 ## Configuration
 
 Strategy configuration is managed through `config/strategy_overrides.yaml`, which supports hot-reload at runtime. The unified daemon watches this file and applies changes without restart.

--- a/tests/test_factory_run_artifacts_layout.py
+++ b/tests/test_factory_run_artifacts_layout.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from factory_run import resolve_run_dir
+
+
+def test_resolve_run_dir_uses_utc_date_subdir(tmp_path) -> None:
+    # 0 ms since epoch -> 1970-01-01 UTC
+    p = resolve_run_dir(artifacts_root=tmp_path, run_id="abc123", generated_at_ms=0)
+    assert p == (tmp_path / "1970-01-01" / "run_abc123").resolve()
+


### PR DESCRIPTION
Implements the standard factory run artifacts layout under the configured artifacts root.

Layout:
- artifacts/YYYY-MM-DD/run_<run_id>/...

Changes:
- factory_run.py now writes runs under a UTC date subdirectory
- README documents the run directory structure

Verification:
- python3 -m pytest -q
- cd backtester && cargo test -q
- cd ws_sidecar && cargo test -q

Closes #35