### PR TITLE
AQC-604: artifact retention + pruning tool

### DIFF
--- a/tests/test_prune_artifacts.py
+++ b/tests/test_prune_artifacts.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from tools.config_id import config_id_from_yaml_text
+from tools.prune_artifacts import prune_artifacts
+from tools.registry_index import ingest_run_dir
+
+
+def _make_run_dir(*, artifacts_root: Path, date: str, run_name: str, run_id: str, generated_at_ms: int) -> Path:
+    run_dir = artifacts_root / date / run_name
+    (run_dir / "configs").mkdir(parents=True, exist_ok=True)
+    (run_dir / "reports").mkdir(parents=True, exist_ok=True)
+
+    yaml_text = "global:\n  trade:\n    leverage: 3\n"
+    cfg_path = run_dir / "configs" / "candidate.yaml"
+    cfg_path.write_text(yaml_text, encoding="utf-8")
+    cfg_id = config_id_from_yaml_text(yaml_text)
+
+    meta = {
+        "run_id": run_id,
+        "generated_at_ms": generated_at_ms,
+        "run_date_utc": date,
+        "run_dir": str(run_dir),
+        "git_head": "deadbeef",
+        "args": {"run_id": run_id},
+        "candidate_configs": [{"path": str(cfg_path), "config_id": cfg_id}],
+    }
+    (run_dir / "run_metadata.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    report = {
+        "items": [
+            {
+                "path": str(run_dir / "replays" / "candidate.replay.json"),
+                "config_path": str(cfg_path),
+                "config_id": cfg_id,
+                "final_balance": 101.0,
+                "total_pnl": 1.0,
+                "total_trades": 2,
+                "win_rate": 0.5,
+                "profit_factor": 1.2,
+                "max_drawdown_pct": 0.1,
+                "total_fees": 0.01,
+            }
+        ]
+    }
+    (run_dir / "reports" / "report.json").write_text(json.dumps(report), encoding="utf-8")
+
+    # Deep dirs we want to prune.
+    (run_dir / "sweeps").mkdir(parents=True, exist_ok=True)
+    (run_dir / "replays").mkdir(parents=True, exist_ok=True)
+    (run_dir / "sweeps" / "dummy.jsonl").write_text("{}", encoding="utf-8")
+    (run_dir / "replays" / "dummy.json").write_text("{}", encoding="utf-8")
+
+    return run_dir
+
+
+def test_prune_artifacts_respects_retention_and_deployed_guard(tmp_path: Path) -> None:
+    artifacts_root = tmp_path / "artifacts"
+    registry_db = artifacts_root / "registry" / "registry.sqlite"
+
+    day_ms = 24 * 60 * 60 * 1000
+    now_ms = 2_000_000_000_000
+    keep_deep_days = 14
+
+    run_old = _make_run_dir(
+        artifacts_root=artifacts_root,
+        date="2026-01-01",
+        run_name="run_old",
+        run_id="old",
+        generated_at_ms=now_ms - (keep_deep_days + 2) * day_ms,
+    )
+    run_deployed = _make_run_dir(
+        artifacts_root=artifacts_root,
+        date="2026-01-02",
+        run_name="run_deployed",
+        run_id="deployed",
+        generated_at_ms=now_ms - (keep_deep_days + 2) * day_ms,
+    )
+    run_new = _make_run_dir(
+        artifacts_root=artifacts_root,
+        date="2026-01-10",
+        run_name="run_new",
+        run_id="new",
+        generated_at_ms=now_ms - (keep_deep_days - 1) * day_ms,
+    )
+
+    ingest_run_dir(registry_db=registry_db, run_dir=run_old)
+    ingest_run_dir(registry_db=registry_db, run_dir=run_deployed)
+    ingest_run_dir(registry_db=registry_db, run_dir=run_new)
+
+    # Mark one run as deployed (must never be pruned).
+    con = sqlite3.connect(str(registry_db))
+    try:
+        con.execute("UPDATE run_configs SET deployed = 1 WHERE run_id = ?", ("deployed",))
+        con.commit()
+    finally:
+        con.close()
+
+    dry = prune_artifacts(
+        artifacts_root=artifacts_root,
+        registry_db=registry_db,
+        keep_deep_days=keep_deep_days,
+        prune_logs=False,
+        dry_run=True,
+        override_now_ms=now_ms,
+    )
+    assert any(a.run_id == "old" and a.deleted for a in dry)
+    assert (run_old / "sweeps").exists()
+    assert (run_old / "replays").exists()
+
+    real = prune_artifacts(
+        artifacts_root=artifacts_root,
+        registry_db=registry_db,
+        keep_deep_days=keep_deep_days,
+        prune_logs=False,
+        dry_run=False,
+        override_now_ms=now_ms,
+    )
+    assert any(a.run_id == "old" and a.deleted for a in real)
+    assert not (run_old / "sweeps").exists()
+    assert not (run_old / "replays").exists()
+    assert (run_old / "prune.json").exists()
+
+    # Deployed run should be untouched.
+    assert (run_deployed / "sweeps").exists()
+    assert (run_deployed / "replays").exists()
+
+    # New run should be within retention.
+    assert (run_new / "sweeps").exists()
+    assert (run_new / "replays").exists()
+

--- a/tools/prune_artifacts.py
+++ b/tools/prune_artifacts.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Prune factory artifacts with a retention policy.
+
+Policy (v1):
+- Keep summaries forever (run_metadata + reports + configs).
+- Prune deep artifacts after N days (default: sweeps/ and replays/; optionally logs/).
+- Never prune runs that have deployed configs recorded in the registry index.
+
+This tool is designed to be run via cron/systemd on the *major-v8* worktree,
+never on the production `master` worktree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    from tools.registry_index import default_registry_db_path
+except ImportError:  # pragma: no cover
+    from registry_index import default_registry_db_path  # type: ignore[no-redef]
+
+
+AIQ_ROOT = Path(__file__).resolve().parents[1]
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _write_json(obj: Any) -> None:
+    sys.stdout.write(json.dumps(obj, indent=2, sort_keys=True) + "\n")
+
+
+def _stderr(msg: str) -> None:
+    sys.stderr.write(str(msg).rstrip("\n") + "\n")
+
+
+def _now_ms(override_now_ms: int | None) -> int:
+    return int(override_now_ms) if override_now_ms is not None else int(time.time() * 1000)
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _connect_ro(path: Path) -> sqlite3.Connection:
+    uri = f"file:{path}?mode=ro"
+    con = sqlite3.connect(uri, uri=True, timeout=2.0)
+    con.row_factory = sqlite3.Row
+    return con
+
+
+def _run_known(con: sqlite3.Connection, *, run_id: str) -> bool:
+    row = con.execute("SELECT 1 FROM runs WHERE run_id = ? LIMIT 1", (run_id,)).fetchone()
+    return row is not None
+
+
+def _run_has_deployed(con: sqlite3.Connection, *, run_id: str) -> bool:
+    row = con.execute(
+        "SELECT 1 FROM run_configs WHERE run_id = ? AND deployed != 0 LIMIT 1",
+        (run_id,),
+    ).fetchone()
+    return row is not None
+
+
+@dataclass(frozen=True)
+class PruneAction:
+    run_id: str
+    run_dir: str
+    age_days: int
+    deleted: list[str]
+    skipped_reason: str | None = None
+
+
+def prune_artifacts(
+    *,
+    artifacts_root: Path,
+    registry_db: Path,
+    keep_deep_days: int,
+    prune_logs: bool,
+    dry_run: bool,
+    override_now_ms: int | None,
+) -> list[PruneAction]:
+    artifacts_root = Path(artifacts_root).expanduser().resolve()
+    registry_db = Path(registry_db).expanduser().resolve()
+    if keep_deep_days < 0:
+        raise ValueError("keep_deep_days must be >= 0")
+
+    if not registry_db.exists():
+        raise FileNotFoundError(f"Registry DB not found: {registry_db}")
+
+    now_ms = _now_ms(override_now_ms)
+    day_ms = 24 * 60 * 60 * 1000
+
+    actions: list[PruneAction] = []
+
+    con = _connect_ro(registry_db)
+    try:
+        for date_dir in sorted([p for p in artifacts_root.iterdir() if p.is_dir() and _DATE_RE.match(p.name)]):
+            for run_dir in sorted([p for p in date_dir.iterdir() if p.is_dir() and p.name.startswith("run_")]):
+                meta_path = run_dir / "run_metadata.json"
+                if not meta_path.exists():
+                    actions.append(
+                        PruneAction(
+                            run_id="",
+                            run_dir=str(run_dir),
+                            age_days=0,
+                            deleted=[],
+                            skipped_reason="missing_run_metadata",
+                        )
+                    )
+                    continue
+
+                meta = _load_json(meta_path)
+                run_id = str(meta.get("run_id", "")).strip()
+                generated_at_ms = int(meta.get("generated_at_ms", 0))
+                if not run_id or generated_at_ms <= 0:
+                    actions.append(
+                        PruneAction(
+                            run_id=run_id,
+                            run_dir=str(run_dir),
+                            age_days=0,
+                            deleted=[],
+                            skipped_reason="invalid_metadata",
+                        )
+                    )
+                    continue
+
+                age_days = int(max(0, (now_ms - generated_at_ms) // day_ms))
+                if age_days <= int(keep_deep_days):
+                    actions.append(
+                        PruneAction(
+                            run_id=run_id,
+                            run_dir=str(run_dir),
+                            age_days=age_days,
+                            deleted=[],
+                            skipped_reason="within_retention",
+                        )
+                    )
+                    continue
+
+                if not _run_known(con, run_id=run_id):
+                    actions.append(
+                        PruneAction(
+                            run_id=run_id,
+                            run_dir=str(run_dir),
+                            age_days=age_days,
+                            deleted=[],
+                            skipped_reason="run_not_in_registry",
+                        )
+                    )
+                    continue
+
+                if _run_has_deployed(con, run_id=run_id):
+                    actions.append(
+                        PruneAction(
+                            run_id=run_id,
+                            run_dir=str(run_dir),
+                            age_days=age_days,
+                            deleted=[],
+                            skipped_reason="has_deployed_configs",
+                        )
+                    )
+                    continue
+
+                deep_dirs = [run_dir / "sweeps", run_dir / "replays"]
+                if prune_logs:
+                    deep_dirs.append(run_dir / "logs")
+
+                deleted: list[str] = []
+                for d in deep_dirs:
+                    if not d.exists():
+                        continue
+                    deleted.append(str(d))
+                    if not dry_run:
+                        shutil.rmtree(d)
+
+                if not dry_run and deleted:
+                    prune_marker = {
+                        "pruned_at_ms": now_ms,
+                        "keep_deep_days": int(keep_deep_days),
+                        "deleted": deleted,
+                    }
+                    (run_dir / "prune.json").write_text(json.dumps(prune_marker, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                actions.append(
+                    PruneAction(
+                        run_id=run_id,
+                        run_dir=str(run_dir),
+                        age_days=age_days,
+                        deleted=deleted,
+                        skipped_reason=None,
+                    )
+                )
+    finally:
+        con.close()
+
+    return actions
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Prune factory artifacts with a retention policy.")
+    ap.add_argument("--artifacts-dir", default="artifacts", help="Artifacts root directory (default: artifacts).")
+    ap.add_argument(
+        "--registry-db",
+        default="",
+        help="Registry DB path (default: artifacts/registry/registry.sqlite).",
+    )
+    ap.add_argument("--keep-deep-days", type=int, default=14, help="Days to keep deep artifacts (default: 14).")
+    ap.add_argument("--prune-logs", action="store_true", help="Also prune logs/ directories.")
+    ap.add_argument("--dry-run", action="store_true", help="Do not delete anything; only report actions.")
+    ap.add_argument("--now-ms", type=int, default=0, help="Override now timestamp (ms) for testing.")
+    args = ap.parse_args(argv)
+
+    artifacts_root = (AIQ_ROOT / str(args.artifacts_dir)).resolve()
+    registry_db = Path(args.registry_db).expanduser().resolve() if args.registry_db else default_registry_db_path(artifacts_root=artifacts_root)
+    now_ms = int(args.now_ms) if int(args.now_ms) > 0 else None
+
+    actions = prune_artifacts(
+        artifacts_root=artifacts_root,
+        registry_db=registry_db,
+        keep_deep_days=int(args.keep_deep_days),
+        prune_logs=bool(args.prune_logs),
+        dry_run=bool(args.dry_run),
+        override_now_ms=now_ms,
+    )
+
+    pruned = [a for a in actions if a.deleted]
+    skipped = [a for a in actions if a.skipped_reason]
+    _stderr(
+        f"[prune] scanned={len(actions)} pruned={len(pruned)} skipped={len(skipped)} dry_run={bool(args.dry_run)}"
+    )
+    _write_json({"actions": [a.__dict__ for a in actions]})
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #38

- Added `tools/prune_artifacts.py` with configurable retention (`--keep-deep-days`) and `--dry-run`.
- Pruning is guarded by the registry index: runs with `deployed=1` are never pruned.
- Added unit test covering retention + deployed guard.