### PR TITLE
AQC-406: Add smoke/daily/deep profiles

### DIFF
--- a/tests/test_factory_run_profile.py
+++ b/tests/test_factory_run_profile.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from factory_run import _parse_cli_args
+
+
+def test_profile_smoke_sets_trials_and_candidate_counts() -> None:
+    args = _parse_cli_args(["--run-id", "x", "--profile", "smoke"])
+    assert args.tpe_trials == 2000
+    assert args.shortlist_per_mode == 3
+    assert args.shortlist_max_rank == 20
+    assert args.num_candidates == 2
+
+
+def test_profile_deep_sets_trials_and_candidate_counts() -> None:
+    args = _parse_cli_args(["--run-id", "x", "--profile", "deep"])
+    assert args.tpe_trials == 500000
+    assert args.shortlist_per_mode == 20
+    assert args.shortlist_max_rank == 200
+    assert args.num_candidates == 5
+
+
+def test_profile_does_not_override_explicit_values() -> None:
+    args = _parse_cli_args(
+        [
+            "--run-id",
+            "x",
+            "--profile",
+            "deep",
+            "--tpe-trials",
+            "123",
+            "--shortlist-per-mode",
+            "7",
+            "--shortlist-max-rank",
+            "77",
+            "--num-candidates",
+            "9",
+        ]
+    )
+    assert args.tpe_trials == 123
+    assert args.shortlist_per_mode == 7
+    assert args.shortlist_max_rank == 77
+    assert args.num_candidates == 9
+


### PR DESCRIPTION
## Summary
- Add `--profile smoke|daily|deep` to control TPE trials and candidate shortlist sizes.
- Keep explicit CLI values as overrides.
- Add unit tests for profile defaults.

Refs #25