### PR TITLE
AQC-706: deployment dry-run YAML validation

### DIFF
--- a/tests/test_deploy_validate.py
+++ b/tests/test_deploy_validate.py
@@ -1,0 +1,36 @@
+from tools.deploy_validate import validate_yaml_text
+
+
+def test_deploy_validate_rejects_missing_global():
+    errs = validate_yaml_text("trade:\n  leverage: 3\n")
+    assert errs
+    assert any("global" in e for e in errs)
+
+
+def test_deploy_validate_rejects_invalid_ema_invariant():
+    y = (
+        "global:\n"
+        "  trade:\n"
+        "    allocation_pct: 0.2\n"
+        "    leverage: 3.0\n"
+        "    sl_atr_mult: 2.0\n"
+        "    tp_atr_mult: 6.0\n"
+        "    slippage_bps: 10.0\n"
+        "    max_open_positions: 20\n"
+        "    max_total_margin_pct: 0.6\n"
+        "    min_notional_usd: 10.0\n"
+        "    min_atr_pct: 0.003\n"
+        "    bump_to_min_notional: true\n"
+        "  indicators:\n"
+        "    adx_window: 14\n"
+        "    ema_fast_window: 50\n"
+        "    ema_slow_window: 20\n"
+        "    bb_window: 20\n"
+        "    atr_window: 14\n"
+        "  thresholds:\n"
+        "    entry:\n"
+        "      min_adx: 22.0\n"
+    )
+    errs = validate_yaml_text(y)
+    assert any("ema_fast_window" in e for e in errs)
+

--- a/tests/test_paper_deploy.py
+++ b/tests/test_paper_deploy.py
@@ -1,8 +1,6 @@
 import json
 import sqlite3
 
-import pytest
-
 from tools.config_id import config_id_from_yaml_text
 from tools.paper_deploy import deploy_paper_config
 
@@ -24,7 +22,31 @@ def _init_registry_db(path, *, config_id, yaml_text):
 
 
 def test_paper_deploy_writes_yaml_and_deploy_event(tmp_path):
-    yaml_text = "global:\\n  engine:\\n    interval: 1h\\n"
+    yaml_text = (
+        "global:\n"
+        "  trade:\n"
+        "    allocation_pct: 0.20\n"
+        "    leverage: 3.0\n"
+        "    sl_atr_mult: 2.0\n"
+        "    tp_atr_mult: 6.0\n"
+        "    slippage_bps: 10.0\n"
+        "    max_open_positions: 20\n"
+        "    max_total_margin_pct: 0.60\n"
+        "    min_notional_usd: 10.0\n"
+        "    min_atr_pct: 0.003\n"
+        "    bump_to_min_notional: true\n"
+        "  indicators:\n"
+        "    adx_window: 14\n"
+        "    ema_fast_window: 20\n"
+        "    ema_slow_window: 50\n"
+        "    bb_window: 20\n"
+        "    atr_window: 14\n"
+        "  thresholds:\n"
+        "    entry:\n"
+        "      min_adx: 22.0\n"
+        "  engine:\n"
+        "    interval: 1h\n"
+    )
     cid = config_id_from_yaml_text(yaml_text)
 
     artifacts_dir = tmp_path / "artifacts"
@@ -44,6 +66,7 @@ def test_paper_deploy_writes_yaml_and_deploy_event(tmp_path):
         restart="never",
         service="does-not-matter",
         dry_run=False,
+        validate=True,
     )
 
     assert deploy_dir.exists()
@@ -57,7 +80,31 @@ def test_paper_deploy_writes_yaml_and_deploy_event(tmp_path):
 
 
 def test_paper_deploy_dry_run_does_not_modify_yaml(tmp_path):
-    yaml_text = "global:\\n  engine:\\n    interval: 1h\\n"
+    yaml_text = (
+        "global:\n"
+        "  trade:\n"
+        "    allocation_pct: 0.20\n"
+        "    leverage: 3.0\n"
+        "    sl_atr_mult: 2.0\n"
+        "    tp_atr_mult: 6.0\n"
+        "    slippage_bps: 10.0\n"
+        "    max_open_positions: 20\n"
+        "    max_total_margin_pct: 0.60\n"
+        "    min_notional_usd: 10.0\n"
+        "    min_atr_pct: 0.003\n"
+        "    bump_to_min_notional: true\n"
+        "  indicators:\n"
+        "    adx_window: 14\n"
+        "    ema_fast_window: 20\n"
+        "    ema_slow_window: 50\n"
+        "    bb_window: 20\n"
+        "    atr_window: 14\n"
+        "  thresholds:\n"
+        "    entry:\n"
+        "      min_adx: 22.0\n"
+        "  engine:\n"
+        "    interval: 1h\n"
+    )
     cid = config_id_from_yaml_text(yaml_text)
 
     artifacts_dir = tmp_path / "artifacts"
@@ -78,7 +125,7 @@ def test_paper_deploy_dry_run_does_not_modify_yaml(tmp_path):
         restart="never",
         service="does-not-matter",
         dry_run=True,
+        validate=True,
     )
 
     assert target_yaml.read_text(encoding="utf-8") == original
-

--- a/tools/deploy_validate.py
+++ b/tools/deploy_validate.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Deployment-time YAML validation (AQC-706).
+
+This validator is designed to fail fast before writing a config to a running engine.
+
+It checks:
+- YAML parses and has the expected `global` mapping shape.
+- A minimal set of required fields exist with sane types/ranges.
+
+It does not attempt to validate strategy performance, only configuration structure.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _is_number(v: Any) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+def _get_path(obj: dict[str, Any], path: str) -> Any:
+    cur: Any = obj
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def validate_config_obj(obj: Any) -> list[str]:
+    errs: list[str] = []
+    if not isinstance(obj, dict):
+        return ["YAML root must be a mapping"]
+
+    glob = obj.get("global")
+    if not isinstance(glob, dict):
+        return ["Missing required mapping: global"]
+
+    def req_map(path: str) -> dict[str, Any] | None:
+        v = _get_path(obj, path)
+        if not isinstance(v, dict):
+            errs.append(f"Missing required mapping: {path}")
+            return None
+        return v
+
+    def req_number(path: str, *, min_v: float | None = None, max_v: float | None = None) -> None:
+        v = _get_path(obj, path)
+        if not _is_number(v):
+            errs.append(f"Missing/invalid number: {path}")
+            return
+        fv = float(v)
+        if min_v is not None and fv < float(min_v):
+            errs.append(f"Out of range (min {min_v}): {path}={fv}")
+        if max_v is not None and fv > float(max_v):
+            errs.append(f"Out of range (max {max_v}): {path}={fv}")
+
+    def req_int(path: str, *, min_v: int | None = None, max_v: int | None = None) -> None:
+        v = _get_path(obj, path)
+        if isinstance(v, bool) or not isinstance(v, int):
+            # Do not accept floats here: keep windows/limits unambiguous.
+            errs.append(f"Missing/invalid int: {path}")
+            return
+        iv = int(v)
+        if min_v is not None and iv < int(min_v):
+            errs.append(f"Out of range (min {min_v}): {path}={iv}")
+        if max_v is not None and iv > int(max_v):
+            errs.append(f"Out of range (max {max_v}): {path}={iv}")
+
+    def req_bool(path: str) -> None:
+        v = _get_path(obj, path)
+        if not isinstance(v, bool):
+            errs.append(f"Missing/invalid bool: {path}")
+
+    # Required mappings
+    req_map("global.trade")
+    req_map("global.indicators")
+    req_map("global.thresholds.entry")
+
+    # Core trade sizing/execution fields
+    req_number("global.trade.allocation_pct", min_v=0.0, max_v=1.0)
+    req_number("global.trade.leverage", min_v=0.0)
+    req_number("global.trade.sl_atr_mult", min_v=0.0)
+    req_number("global.trade.tp_atr_mult", min_v=0.0)
+    req_number("global.trade.slippage_bps", min_v=0.0)
+    req_int("global.trade.max_open_positions", min_v=1)
+    req_number("global.trade.max_total_margin_pct", min_v=0.0, max_v=1.0)
+    req_number("global.trade.min_notional_usd", min_v=0.0)
+    req_number("global.trade.min_atr_pct", min_v=0.0, max_v=1.0)
+    req_bool("global.trade.bump_to_min_notional")
+
+    # Key indicator windows
+    req_int("global.indicators.adx_window", min_v=1)
+    req_int("global.indicators.ema_fast_window", min_v=1)
+    req_int("global.indicators.ema_slow_window", min_v=1)
+    req_int("global.indicators.bb_window", min_v=1)
+    req_int("global.indicators.atr_window", min_v=1)
+
+    # Entry threshold sanity
+    req_number("global.thresholds.entry.min_adx", min_v=0.0)
+
+    # Invariants
+    fast = _get_path(obj, "global.indicators.ema_fast_window")
+    slow = _get_path(obj, "global.indicators.ema_slow_window")
+    if isinstance(fast, int) and isinstance(slow, int) and fast >= slow:
+        errs.append("Invalid invariant: global.indicators.ema_fast_window must be < ema_slow_window")
+
+    return errs
+
+
+def validate_yaml_text(text: str) -> list[str]:
+    try:
+        obj = yaml.safe_load(text) or {}
+    except Exception as e:
+        return [f"YAML parse error: {type(e).__name__}: {e}"]
+    return validate_config_obj(obj)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Validate a strategy overrides YAML before deploying.")
+    ap.add_argument("--config", required=True, help="Path to a YAML config file to validate.")
+    args = ap.parse_args(argv)
+
+    cfg_path = Path(args.config).expanduser().resolve()
+    text = cfg_path.read_text(encoding="utf-8")
+    errs = validate_yaml_text(text)
+    if errs:
+        for e in errs:
+            print(f"[invalid] {e}")
+        return 1
+    print("[ok] config validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Adds a fast, deployment-time YAML schema validator and wires it into paper deploy so invalid configs fail before write/restart.

- Adds `tools/deploy_validate.py` (minimal required fields + sanity invariants)
- `tools/paper_deploy.py` validates by default; `--no-validate` bypasses

Closes #45.