### PR TITLE
AQC-704: rollback to last-known-good config

### DIFF
--- a/tests/test_rollback_to_last_good.py
+++ b/tests/test_rollback_to_last_good.py
@@ -1,0 +1,88 @@
+import json
+
+from tools.rollback_to_last_good import rollback_to_last_good
+
+
+VALID_YAML = (
+    "global:\n"
+    "  trade:\n"
+    "    allocation_pct: 0.20\n"
+    "    leverage: 3.0\n"
+    "    sl_atr_mult: 2.0\n"
+    "    tp_atr_mult: 6.0\n"
+    "    slippage_bps: 10.0\n"
+    "    max_open_positions: 20\n"
+    "    max_total_margin_pct: 0.60\n"
+    "    min_notional_usd: 10.0\n"
+    "    min_atr_pct: 0.003\n"
+    "    bump_to_min_notional: true\n"
+    "  indicators:\n"
+    "    adx_window: 14\n"
+    "    ema_fast_window: 20\n"
+    "    ema_slow_window: 50\n"
+    "    bb_window: 20\n"
+    "    atr_window: 14\n"
+    "  thresholds:\n"
+    "    entry:\n"
+    "      min_adx: 22.0\n"
+    "  engine:\n"
+    "    interval: 1h\n"
+)
+
+
+def test_rollback_to_last_good_uses_prev_config_yaml(tmp_path):
+    artifacts = tmp_path / "artifacts"
+    deploy_root = artifacts / "deployments" / "paper"
+    deploy_root.mkdir(parents=True, exist_ok=True)
+
+    latest = deploy_root / "20260210T100000Z_deadbeef"
+    latest.mkdir(parents=True, exist_ok=True)
+    (latest / "prev_config.yaml").write_text(VALID_YAML, encoding="utf-8")
+
+    target_yaml = tmp_path / "strategy_overrides.yaml"
+    target_yaml.write_text("global:\n  engine:\n    interval: 30m\n", encoding="utf-8")
+
+    rb_dir = rollback_to_last_good(
+        artifacts_dir=artifacts,
+        yaml_path=target_yaml,
+        steps=1,
+        reason="unit test rollback",
+        restart="never",
+        service="does-not-matter",
+        dry_run=False,
+    )
+
+    assert target_yaml.read_text(encoding="utf-8").strip() == VALID_YAML.strip()
+    event = json.loads((rb_dir / "rollback_event.json").read_text(encoding="utf-8"))
+    assert event["why"]["reason"] == "unit test rollback"
+
+
+def test_rollback_to_last_good_falls_back_to_older_deployed_config(tmp_path):
+    artifacts = tmp_path / "artifacts"
+    deploy_root = artifacts / "deployments" / "paper"
+    deploy_root.mkdir(parents=True, exist_ok=True)
+
+    latest = deploy_root / "20260210T100000Z_deadbeef"
+    older = deploy_root / "20260210T090000Z_cafebabe"
+    latest.mkdir(parents=True, exist_ok=True)
+    older.mkdir(parents=True, exist_ok=True)
+
+    # Empty prev_config.yaml forces fallback.
+    (latest / "prev_config.yaml").write_text("", encoding="utf-8")
+    (older / "deployed_config.yaml").write_text(VALID_YAML, encoding="utf-8")
+
+    target_yaml = tmp_path / "strategy_overrides.yaml"
+    target_yaml.write_text("global:\n  engine:\n    interval: 30m\n", encoding="utf-8")
+
+    rb_dir = rollback_to_last_good(
+        artifacts_dir=artifacts,
+        yaml_path=target_yaml,
+        steps=1,
+        reason="unit test fallback",
+        restart="never",
+        service="does-not-matter",
+        dry_run=False,
+    )
+
+    assert target_yaml.read_text(encoding="utf-8").strip() == VALID_YAML.strip()
+    assert (rb_dir / "restored_config.yaml").exists()

--- a/tools/paper_deploy.py
+++ b/tools/paper_deploy.py
@@ -204,6 +204,7 @@ def deploy_paper_config(
 
     # Always write the artefact, even in dry-run mode.
     (deploy_dir / "deployed_config.yaml").write_text(yaml_text, encoding="utf-8")
+    (deploy_dir / "prev_config.yaml").write_text(prev_text, encoding="utf-8")
 
     if not dry_run:
         _atomic_write_text(yaml_path, yaml_text)

--- a/tools/rollback_to_last_good.py
+++ b/tools/rollback_to_last_good.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Rollback to last-known-good config for paper trading (AQC-704).
+
+This command restores the previous config captured by `tools/paper_deploy.py`
+and records a rollback event with a human reason.
+
+It is intended for emergency response and should be used with care.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    from tools.deploy_validate import validate_yaml_text
+except ImportError:  # pragma: no cover
+    from deploy_validate import validate_yaml_text  # type: ignore[no-redef]
+
+
+AIQ_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class RestartResult:
+    attempted: bool
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+def _utc_now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _utc_compact() -> str:
+    return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(str(tmp), str(path))
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_yaml_engine_interval(yaml_text: str) -> str:
+    try:
+        import yaml
+
+        obj = yaml.safe_load(yaml_text) or {}
+        if not isinstance(obj, dict):
+            return ""
+        glob = obj.get("global", {}) if isinstance(obj.get("global", {}), dict) else {}
+        eng = glob.get("engine", {}) if isinstance(glob.get("engine", {}), dict) else {}
+        iv = eng.get("interval", "")
+        return str(iv or "").strip()
+    except Exception:
+        return ""
+
+
+def _restart_systemd_user_service(service: str) -> RestartResult:
+    service = str(service).strip()
+    if not service:
+        return RestartResult(attempted=False, exit_code=0, stdout="", stderr="service name is empty")
+
+    proc = subprocess.run(
+        ["systemctl", "--user", "restart", service],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return RestartResult(
+        attempted=True,
+        exit_code=int(proc.returncode),
+        stdout=str(proc.stdout or ""),
+        stderr=str(proc.stderr or ""),
+    )
+
+
+def _list_deploy_dirs(deploy_root: Path) -> list[Path]:
+    if not deploy_root.exists():
+        return []
+    dirs = [p for p in deploy_root.iterdir() if p.is_dir()]
+    # Directories are prefixed with UTC timestamps; sort lexicographically desc.
+    return sorted(dirs, key=lambda p: p.name, reverse=True)
+
+
+def rollback_to_last_good(
+    *,
+    artifacts_dir: Path,
+    yaml_path: Path,
+    steps: int,
+    reason: str,
+    restart: str,
+    service: str,
+    dry_run: bool,
+) -> Path:
+    artifacts_dir = Path(artifacts_dir).expanduser().resolve()
+    yaml_path = Path(yaml_path).expanduser().resolve()
+
+    deploy_root = (artifacts_dir / "deployments" / "paper").resolve()
+    deploy_dirs = _list_deploy_dirs(deploy_root)
+    steps = int(steps)
+    if steps <= 0:
+        steps = 1
+    if len(deploy_dirs) < steps:
+        raise FileNotFoundError(f"Not enough deployments under {deploy_root} for steps={steps}")
+
+    src_dir = deploy_dirs[steps - 1]
+    prev_path = src_dir / "prev_config.yaml"
+    restored_text = _read_text(prev_path).strip()
+    restored_from = str(prev_path)
+
+    # Fallback: use the deployed_config.yaml from the next older deployment.
+    if not restored_text:
+        if len(deploy_dirs) >= steps + 1:
+            alt_dir = deploy_dirs[steps]
+            alt_path = alt_dir / "deployed_config.yaml"
+            restored_text = _read_text(alt_path).strip()
+            restored_from = str(alt_path)
+        if not restored_text:
+            raise FileNotFoundError("Could not locate a rollback config (prev_config.yaml missing/empty).")
+
+    errs = validate_yaml_text(restored_text)
+    if errs:
+        msg = "Rollback config failed validation:\n" + "\n".join([f"- {e}" for e in errs])
+        raise ValueError(msg)
+
+    current_text = _read_text(yaml_path)
+    cur_interval = _load_yaml_engine_interval(current_text)
+    next_interval = _load_yaml_engine_interval(restored_text)
+    restart_required = bool(cur_interval and next_interval and cur_interval != next_interval)
+
+    ts = _utc_compact()
+    rollback_dir = (artifacts_dir / "rollbacks" / "paper" / ts).resolve()
+    rollback_dir.mkdir(parents=True, exist_ok=True)
+
+    (rollback_dir / "restored_config.yaml").write_text(restored_text + "\n", encoding="utf-8")
+
+    event: dict[str, Any] = {
+        "version": "rollback_event_v1",
+        "ts_utc": _utc_now_iso(),
+        "ts_compact_utc": ts,
+        "who": {"user": getpass.getuser(), "hostname": socket.gethostname()},
+        "what": {
+            "mode": "paper",
+            "yaml_path": str(yaml_path),
+            "source_deploy_dir": str(src_dir),
+            "restored_from": str(restored_from),
+            "current_yaml_sha256": hashlib.sha256(current_text.encode("utf-8")).hexdigest() if current_text else "",
+            "restored_yaml_sha256": hashlib.sha256(restored_text.encode("utf-8")).hexdigest(),
+            "current_engine_interval": cur_interval,
+            "restored_engine_interval": next_interval,
+            "restart_required": bool(restart_required),
+            "steps": int(steps),
+        },
+        "why": {"reason": str(reason or "").strip()},
+        "dry_run": bool(dry_run),
+        "restart": {"mode": str(restart), "service": str(service), "result": None},
+    }
+
+    if not dry_run:
+        _atomic_write_text(yaml_path, restored_text + "\n")
+
+    restart_mode = str(restart or "auto").strip().lower()
+    do_restart = (restart_mode == "always") or (restart_mode == "auto" and restart_required)
+    if do_restart and not dry_run:
+        rr = _restart_systemd_user_service(str(service))
+        event["restart"]["result"] = rr.__dict__
+        if rr.attempted and rr.exit_code != 0:
+            (rollback_dir / "rollback_event.json").write_text(json.dumps(event, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            raise RuntimeError(f"service restart failed: {service} (exit_code={rr.exit_code})")
+
+    (rollback_dir / "rollback_event.json").write_text(json.dumps(event, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return rollback_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Rollback paper trading config to last-known-good.")
+    ap.add_argument("--artifacts-dir", default="artifacts", help="Artifacts root (default: artifacts).")
+    ap.add_argument(
+        "--yaml-path",
+        default=str(AIQ_ROOT / "config" / "strategy_overrides.yaml"),
+        help="Target strategy overrides YAML path (default: config/strategy_overrides.yaml).",
+    )
+    ap.add_argument("--steps", type=int, default=1, help="How many deploy steps to roll back (default: 1).")
+    ap.add_argument("--reason", default="", help="Human reason for rollback (recorded).")
+    ap.add_argument(
+        "--restart",
+        default="auto",
+        choices=["auto", "always", "never"],
+        help="Restart policy (default: auto).",
+    )
+    ap.add_argument(
+        "--service",
+        default="openclaw-ai-quant-trader",
+        help="systemd user service name for paper trader (default: openclaw-ai-quant-trader).",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="Write artefacts but do not modify YAML or restart.")
+    args = ap.parse_args(argv)
+
+    rollback_to_last_good(
+        artifacts_dir=Path(args.artifacts_dir),
+        yaml_path=Path(args.yaml_path),
+        steps=int(args.steps),
+        reason=str(args.reason),
+        restart=str(args.restart),
+        service=str(args.service),
+        dry_run=bool(args.dry_run),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Adds an automated rollback command and records rollback reasons for auditability.

- Adds `tools/rollback_to_last_good.py` (restores from latest paper deploy artefacts)
- `tools/paper_deploy.py` now captures `prev_config.yaml` per deploy
- Emits `rollback_event.json` under `artifacts/rollbacks/paper/`

Closes #43.