### PR TITLE
AQC-804: Slippage anomaly guard

### DIFF
--- a/live/trader.py
+++ b/live/trader.py
@@ -2794,12 +2794,46 @@ def process_user_fills(trader: LiveTrader, fills: list[dict]) -> int:
                     risk = getattr(trader, "risk", None)
                     note = getattr(risk, "note_fill", None) if risk is not None else None
                     if callable(note):
+                        fill_side = None
+                        try:
+                            dl = str(dir_s or "").strip().lower()
+                            if dl.startswith("open") and "long" in dl:
+                                fill_side = "BUY"
+                            elif dl.startswith("open") and "short" in dl:
+                                fill_side = "SELL"
+                            elif dl.startswith("close") and "long" in dl:
+                                fill_side = "SELL"
+                            elif dl.startswith("close") and "short" in dl:
+                                fill_side = "BUY"
+                        except Exception:
+                            fill_side = None
+
+                        ref_mid = None
+                        ref_bid = None
+                        ref_ask = None
+                        try:
+                            bbo = hyperliquid_ws.hl_ws.get_bbo(sym, max_age_s=10.0)
+                            if bbo is not None:
+                                ref_bid, ref_ask = float(bbo[0]), float(bbo[1])
+                            ref_mid = hyperliquid_ws.hl_ws.get_mid(sym, max_age_s=10.0)
+                            if ref_mid is not None:
+                                ref_mid = float(ref_mid)
+                        except Exception:
+                            ref_mid = None
+                            ref_bid = None
+                            ref_ask = None
+
                         note(
                             ts_ms=int(t_ms),
                             symbol=str(sym),
                             action=str(action),
                             pnl_usd=float(pnl or 0.0),
                             fee_usd=float(fee or 0.0),
+                            fill_price=float(px),
+                            side=str(fill_side or ""),
+                            ref_mid=ref_mid,
+                            ref_bid=ref_bid,
+                            ref_ask=ref_ask,
                         )
                 except Exception:
                     pass
@@ -2900,12 +2934,46 @@ def process_user_fills(trader: LiveTrader, fills: list[dict]) -> int:
                 risk = getattr(trader, "risk", None)
                 note = getattr(risk, "note_fill", None) if risk is not None else None
                 if callable(note):
+                    fill_side = None
+                    try:
+                        dl = str(dir_s or "").strip().lower()
+                        if dl.startswith("open") and "long" in dl:
+                            fill_side = "BUY"
+                        elif dl.startswith("open") and "short" in dl:
+                            fill_side = "SELL"
+                        elif dl.startswith("close") and "long" in dl:
+                            fill_side = "SELL"
+                        elif dl.startswith("close") and "short" in dl:
+                            fill_side = "BUY"
+                    except Exception:
+                        fill_side = None
+
+                    ref_mid = None
+                    ref_bid = None
+                    ref_ask = None
+                    try:
+                        bbo = hyperliquid_ws.hl_ws.get_bbo(sym, max_age_s=10.0)
+                        if bbo is not None:
+                            ref_bid, ref_ask = float(bbo[0]), float(bbo[1])
+                        ref_mid = hyperliquid_ws.hl_ws.get_mid(sym, max_age_s=10.0)
+                        if ref_mid is not None:
+                            ref_mid = float(ref_mid)
+                    except Exception:
+                        ref_mid = None
+                        ref_bid = None
+                        ref_ask = None
+
                     note(
                         ts_ms=int(t_ms),
                         symbol=str(sym),
                         action=str(action),
                         pnl_usd=float(pnl or 0.0),
                         fee_usd=float(fee or 0.0),
+                        fill_price=float(px),
+                        side=str(fill_side or ""),
+                        ref_mid=ref_mid,
+                        ref_bid=ref_bid,
+                        ref_ask=ref_ask,
                     )
             except Exception:
                 pass

--- a/tests/test_risk_slippage_guard.py
+++ b/tests/test_risk_slippage_guard.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+
+def _bootstrap(tmp_path, monkeypatch, *, yaml_text: str) -> None:
+    cfg = tmp_path / "strategy_overrides.yaml"
+    cfg.write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setenv("AI_QUANT_STRATEGY_YAML", str(cfg))
+
+    from engine.strategy_manager import StrategyManager
+
+    StrategyManager.bootstrap(
+        defaults={"trade": {}, "indicators": {}, "filters": {}, "thresholds": {}},
+        yaml_path=str(cfg),
+        changelog_path=None,
+    )
+
+
+def test_slippage_guard_triggers_on_median_breach(tmp_path, monkeypatch):
+    _bootstrap(
+        tmp_path,
+        monkeypatch,
+        yaml_text=(
+            "global:\n"
+            "  risk:\n"
+            "    slippage_guard:\n"
+            "      enabled: true\n"
+            "      window_fills: 3\n"
+            "      max_median_bps: 5\n"
+        ),
+    )
+
+    from engine.risk import RiskManager
+
+    risk = RiskManager()
+    risk.refresh(trader=None)
+
+    for _ in range(3):
+        risk.note_fill(
+            ts_ms=1,
+            symbol="BTC",
+            action="OPEN",
+            pnl_usd=0.0,
+            fee_usd=0.0,
+            fill_price=100.10,
+            side="BUY",
+            ref_ask=100.00,
+        )
+
+    assert risk.kill_mode == "close_only"
+    assert risk.kill_reason == "slippage_guard"
+
+
+def test_slippage_guard_uses_median_not_outliers(tmp_path, monkeypatch):
+    _bootstrap(
+        tmp_path,
+        monkeypatch,
+        yaml_text=(
+            "global:\n"
+            "  risk:\n"
+            "    slippage_guard:\n"
+            "      enabled: true\n"
+            "      window_fills: 3\n"
+            "      max_median_bps: 5\n"
+        ),
+    )
+
+    from engine.risk import RiskManager
+
+    risk = RiskManager()
+    risk.refresh(trader=None)
+
+    # Window: [0, 20, 0] bps -> median is 0 -> should not kill.
+    risk.note_fill(
+        ts_ms=1,
+        symbol="BTC",
+        action="OPEN",
+        pnl_usd=0.0,
+        fee_usd=0.0,
+        fill_price=100.00,
+        side="BUY",
+        ref_ask=100.00,
+    )
+    risk.note_fill(
+        ts_ms=2,
+        symbol="BTC",
+        action="OPEN",
+        pnl_usd=0.0,
+        fee_usd=0.0,
+        fill_price=100.20,
+        side="BUY",
+        ref_ask=100.00,
+    )
+    risk.note_fill(
+        ts_ms=3,
+        symbol="BTC",
+        action="OPEN",
+        pnl_usd=0.0,
+        fee_usd=0.0,
+        fill_price=100.00,
+        side="BUY",
+        ref_ask=100.00,
+    )
+
+    assert risk.kill_mode == "off"
+
+
+def test_slippage_guard_ignores_non_entry_actions(tmp_path, monkeypatch):
+    _bootstrap(
+        tmp_path,
+        monkeypatch,
+        yaml_text=(
+            "global:\n"
+            "  risk:\n"
+            "    slippage_guard:\n"
+            "      enabled: true\n"
+            "      window_fills: 3\n"
+            "      max_median_bps: 1\n"
+        ),
+    )
+
+    from engine.risk import RiskManager
+
+    risk = RiskManager()
+    risk.refresh(trader=None)
+
+    for _ in range(3):
+        risk.note_fill(
+            ts_ms=1,
+            symbol="BTC",
+            action="CLOSE",
+            pnl_usd=0.0,
+            fee_usd=0.0,
+            fill_price=100.10,
+            side="SELL",
+            ref_bid=100.00,
+        )
+
+    assert risk.kill_mode == "off"
+


### PR DESCRIPTION
## Summary
- Computes live slippage from fills vs mid/BBO and maintains a rolling window over entry fills (OPEN/ADD).
- If the median slippage over the last N fills exceeds the configured threshold, the RiskManager triggers a close-only kill and emits a structured audit event.

## Configuration
- YAML: global.risk.slippage_guard.enabled / window_fills / max_median_bps
- Env overrides: AI_QUANT_RISK_SLIPPAGE_GUARD_ENABLED / AI_QUANT_RISK_SLIPPAGE_GUARD_WINDOW_FILLS / AI_QUANT_RISK_SLIPPAGE_GUARD_MAX_MEDIAN_BPS

Fixes #49