### PR TITLE
AQC-703: Live rollout ramp (position sizing multiplier)

### DIFF
--- a/engine/core.py
+++ b/engine/core.py
@@ -1092,7 +1092,13 @@ class UnifiedEngine:
                         open_pos = 0
 
                     loop_s = time.time() - loop_start
-                    _rc = (mei_alpha_v1.get_strategy_config("BTC") or {}).get("market_regime") or {}
+                    _btc_cfg = mei_alpha_v1.get_strategy_config("BTC") or {}
+                    _rc = (_btc_cfg.get("market_regime") or {}) if isinstance(_btc_cfg, dict) else {}
+                    _tc = (_btc_cfg.get("trade") or {}) if isinstance(_btc_cfg, dict) else {}
+                    try:
+                        _size_mult = float(_tc.get("size_multiplier", 1.0))
+                    except Exception:
+                        _size_mult = 1.0
                     _auto_rev_on = (
                         bool(_rc.get("enable_auto_reverse", False))
                         and self._market_breadth_pct is not None
@@ -1101,6 +1107,7 @@ class UnifiedEngine:
                     print(
                         f"🫀 engine ok. loops={self.stats.loops} errors={self.stats.loop_errors} "
                         f"symbols={len(active_symbols)} open_pos={open_pos} loop={loop_s:.2f}s "
+                        f"size_mult={float(_size_mult):g} "
                         f"ws_connected={h.get('connected')} ws_thread_alive={h.get('thread_alive')} "
                         f"ws_restarts={self.stats.ws_restarts} "
                         f"signal_on_close={int(self._signal_on_candle_close)} entry_iv={self._entry_interval} exit_iv={self._exit_interval} reanalyze_s={self._reanalyze_interval_s:.0f} exit_reanalyze_s={self._exit_reanalyze_interval_s:.0f} "

--- a/live/trader.py
+++ b/live/trader.py
@@ -888,6 +888,14 @@ class LiveTrader(mei_alpha_v1.PaperTrader):
             vol_scalar = max(vol_min, min(vol_max, vol_scalar))
             margin_target *= max(0.0, vol_scalar)
 
+        # Optional size multiplier (used for live rollout ramps, etc).
+        try:
+            size_mult = float(trade_cfg.get("size_multiplier", 1.0))
+        except Exception:
+            size_mult = 1.0
+        size_mult = max(0.0, float(size_mult))
+        margin_target *= float(size_mult)
+
         # Live-specific clamps
         min_margin_usd = _safe_float(trade_cfg.get("min_margin_usd"), 0.0)
         if min_margin_usd > 0:
@@ -1256,6 +1264,7 @@ class LiveTrader(mei_alpha_v1.PaperTrader):
                 "notional_est": float(notional),
                 "leverage": float(leverage),
                 "margin_est": float(margin_add),
+                "size_multiplier": float(size_mult),
             },
         )
 
@@ -2448,6 +2457,11 @@ class LiveTrader(mei_alpha_v1.PaperTrader):
             except Exception:
                 pass
 
+        try:
+            size_mult = float(trade_cfg.get("size_multiplier", 1.0))
+        except Exception:
+            size_mult = 1.0
+
         print(
             f"🚀 LIVE ORDER sent: OPEN {('LONG' if signal == 'BUY' else 'SHORT')} {sym} "
             f"px~={float(fill_price_est):.4f} size={size:.6f} notional~=${notional:.2f} "
@@ -2464,6 +2478,7 @@ class LiveTrader(mei_alpha_v1.PaperTrader):
                 "notional_est": float(notional),
                 "leverage": float(leverage),
                 "margin_est": float(margin_need),
+                "size_multiplier": float(size_mult),
             },
         )
 

--- a/strategy/mei_alpha_v1.py
+++ b/strategy/mei_alpha_v1.py
@@ -711,6 +711,14 @@ def compute_entry_sizing(
             vol_scalar = max(vol_min, min(vol_max, vol_scalar))
             margin_target *= max(0.0, vol_scalar)
 
+    # Optional size multiplier (used for live rollout ramps, etc).
+    try:
+        size_mult = float(trade_cfg.get("size_multiplier", 1.0))
+    except Exception:
+        size_mult = 1.0
+    size_mult = max(0.0, float(size_mult))
+    margin_target *= float(size_mult)
+
     # Optional floor clamp (primarily for live so you clear min-notional after rounding).
     min_margin = _safe_float(trade_cfg.get("min_margin_usd"), None)
     if min_margin is not None and float(min_margin) > 0:
@@ -1985,6 +1993,14 @@ class PaperTrader:
             vol_max = float(trade_cfg.get("vol_scalar_max", 1.0))
             vol_scalar = max(vol_min, min(vol_max, vol_scalar))
             margin_target *= max(0.0, vol_scalar)
+
+        # Optional size multiplier (used for live rollout ramps, etc).
+        try:
+            size_mult = float(trade_cfg.get("size_multiplier", 1.0))
+        except Exception:
+            size_mult = 1.0
+        size_mult = max(0.0, float(size_mult))
+        margin_target *= float(size_mult)
 
         # Margin cap across all symbols (use live marks if possible).
         current_margin = 0.0


### PR DESCRIPTION
## Summary
- Adds `trade.size_multiplier` (YAML hot-reloadable) to scale entry sizing for OPEN and ADD orders.
- Emits the active multiplier in the engine heartbeat line (runtime_logs), and includes it in live order audit events.

## Usage
- Set `global.trade.size_multiplier` (or per-symbol override) to values like 0.25, 0.5, 1.0.

Fixes #42