### PR TITLE
AQC-902: Real-time health dashboard (config_id, PnL, PAUSED)

### DIFF
--- a/engine/core.py
+++ b/engine/core.py
@@ -1104,15 +1104,34 @@ class UnifiedEngine:
                         and self._market_breadth_pct is not None
                         and float(_rc.get("auto_reverse_breadth_low", 20.0)) <= self._market_breadth_pct <= float(_rc.get("auto_reverse_breadth_high", 80.0))
                     )
+                    cfg_id = ""
+                    try:
+                        from .event_logger import current_config_id
+
+                        cfg_id = str(current_config_id() or "")
+                    except Exception:
+                        cfg_id = ""
+
+                    risk = getattr(self.trader, "risk", None)
+                    try:
+                        kill_mode = str(getattr(risk, "kill_mode", "off") or "off").strip().lower()
+                    except Exception:
+                        kill_mode = "off"
+                    try:
+                        kill_reason = str(getattr(risk, "kill_reason", "") or "").strip() or "none"
+                    except Exception:
+                        kill_reason = "none"
                     print(
                         f"🫀 engine ok. loops={self.stats.loops} errors={self.stats.loop_errors} "
                         f"symbols={len(active_symbols)} open_pos={open_pos} loop={loop_s:.2f}s "
                         f"size_mult={float(_size_mult):g} "
                         f"ws_connected={h.get('connected')} ws_thread_alive={h.get('thread_alive')} "
                         f"ws_restarts={self.stats.ws_restarts} "
+                        f"kill={kill_mode} kill_reason={kill_reason} "
                         f"signal_on_close={int(self._signal_on_candle_close)} entry_iv={self._entry_interval} exit_iv={self._exit_interval} reanalyze_s={self._reanalyze_interval_s:.0f} exit_reanalyze_s={self._exit_reanalyze_interval_s:.0f} "
                         f"breadth={f'{self._market_breadth_pct:.1f}%' if self._market_breadth_pct is not None else 'n/a'} "
                         f"auto_rev={'ON' if _auto_rev_on else 'OFF'} "
+                        f"config_id={cfg_id or 'none'} "
                         f"strategy_sha1={str(snap.overrides_sha1 or '')[:8]} version={snap.version or 'n/a'}"
                     )
                     self.stats.last_heartbeat_s = time.time()

--- a/engine/event_logger.py
+++ b/engine/event_logger.py
@@ -98,6 +98,14 @@ def _current_config_id() -> str:
     return str(cid)
 
 
+def current_config_id() -> str:
+    """Return the current config_id (sha256 of the normalised strategy YAML)."""
+    try:
+        return _current_config_id()
+    except Exception:
+        return ""
+
+
 @dataclass(frozen=True)
 class _EventItem:
     line: str
@@ -239,4 +247,3 @@ def _close_for_tests() -> None:
             return
         _SINK.close()
         _SINK = None
-

--- a/monitor/heartbeat.py
+++ b/monitor/heartbeat.py
@@ -29,6 +29,9 @@ _HB_OPEN_POS_RE = re.compile(r"open_pos=([0-9]+)", re.IGNORECASE)
 _HB_WS_CONNECTED_RE = re.compile(r"ws_connected=(True|False)", re.IGNORECASE)
 _HB_WS_THREAD_RE = re.compile(r"ws_thread_alive=(True|False)", re.IGNORECASE)
 _HB_WS_RESTARTS_RE = re.compile(r"ws_restarts=([0-9]+)", re.IGNORECASE)
+_HB_KILL_MODE_RE = re.compile(r"kill=(off|close_only|halt_all)", re.IGNORECASE)
+_HB_KILL_REASON_RE = re.compile(r"kill_reason=([^\s]+)", re.IGNORECASE)
+_HB_CONFIG_ID_RE = re.compile(r"config_id=([0-9a-f]{8,64}|none)", re.IGNORECASE)
 
 
 def connect_db_ro(db_path: Path) -> sqlite3.Connection:
@@ -148,4 +151,15 @@ def parse_last_heartbeat(db_path: Path, log_path: Path) -> dict[str, Any]:
     wsr_m = _HB_WS_RESTARTS_RE.search(last_line)
     if wsr_m:
         out["ws_restarts"] = int(wsr_m.group(1))
+    km_m = _HB_KILL_MODE_RE.search(last_line)
+    if km_m:
+        out["kill_mode"] = km_m.group(1).lower()
+    kr_m = _HB_KILL_REASON_RE.search(last_line)
+    if kr_m:
+        out["kill_reason"] = kr_m.group(1)
+    cid_m = _HB_CONFIG_ID_RE.search(last_line)
+    if cid_m:
+        cid = cid_m.group(1).lower()
+        if cid != "none":
+            out["config_id"] = cid
     return out

--- a/monitor/static/index.html
+++ b/monitor/static/index.html
@@ -49,6 +49,31 @@
           <span class="pillv" id="balEq">&mdash;</span>
         </div>
 
+        <div class="pill pill-state" id="statePill" title="Risk kill switch state">
+          <span class="dot" id="stateDot"></span>
+          <span class="pilltxt" id="stateTxt" aria-live="polite">running</span>
+        </div>
+
+        <div class="pill pill-val" id="cfgPill" title="Active config_id (from engine heartbeat)">
+          <span class="pillk">cfg</span>
+          <span class="pillv" id="cfgId">&mdash;</span>
+        </div>
+
+        <div class="pill pill-val" id="pnlTodayPill" title="Today's PnL (UTC day, realised balance delta)">
+          <span class="pillk">pnl</span>
+          <span class="pillv" id="pnlToday">&mdash;</span>
+        </div>
+
+        <div class="pill pill-val" id="ddPill" title="Drawdown from peak realised balance (UTC day)">
+          <span class="pillk">dd</span>
+          <span class="pillv" id="ddNow">&mdash;</span>
+        </div>
+
+        <div class="pill pill-val" id="dataPill" title="Last market data timestamp (WS mids)">
+          <span class="pillk">data</span>
+          <span class="pillv" id="dataTs">&mdash;</span>
+        </div>
+
         <label class="search">
           <span class="kbd">/</span>
           <input id="search" type="search" placeholder="Filter symbols..." autocomplete="off" />

--- a/monitor/static/styles.css
+++ b/monitor/static/styles.css
@@ -247,6 +247,17 @@ button, input, summary { touch-action: manipulation; }
   font-weight: 500;
 }
 
+.pill.paused {
+  border-color: var(--accent2-border);
+  background: var(--accent2-dim);
+  color: var(--txt);
+}
+
+.pill.running {
+  border-color: var(--ok-border);
+  background: var(--ok-dim);
+}
+
 
 /* ============================================================
    CONNECTION DOT
@@ -260,6 +271,10 @@ button, input, summary { touch-action: manipulation; }
 .dot.ok {
   background: var(--ok);
   box-shadow: 0 0 6px rgba(0,230,118,0.45), 0 0 2px rgba(0,230,118,0.7);
+}
+.dot.warn {
+  background: var(--warn);
+  box-shadow: 0 0 6px rgba(255,167,38,0.45), 0 0 2px rgba(255,167,38,0.7);
 }
 .dot.bad {
   background: var(--accent2);


### PR DESCRIPTION
Fixes #55.

Extends the existing monitor web UI to show:
- config_id (from engine heartbeat)
- risk state (RUNNING / PAUSED / HALT), clearly visible
- today PnL and drawdown (UTC day)
- last market data timestamp (WS mids)

Implementation notes:
- Engine heartbeat now includes kill state + config_id tokens.
- Heartbeat parser and tests updated accordingly.
- Monitor snapshot includes daily metrics derived from the trading DB.
