### PR TITLE
AQC-807: Exposure concentration limit

### DIFF
--- a/live/trader.py
+++ b/live/trader.py
@@ -1037,6 +1037,7 @@ class LiveTrader(mei_alpha_v1.PaperTrader):
                     side=side,
                     notional_usd=float(notional),
                     leverage=float(leverage),
+                    positions=getattr(self, "positions", None),
                     intent_id=getattr(oms_intent, "intent_id", None),
                     reduce_risk=False,
                 )
@@ -2211,6 +2212,7 @@ class LiveTrader(mei_alpha_v1.PaperTrader):
                     side=entry_side,
                     notional_usd=float(notional),
                     leverage=float(leverage),
+                    positions=getattr(self, "positions", None),
                     intent_id=getattr(oms_intent, "intent_id", None),
                     reduce_risk=False,
                 )

--- a/tests/test_risk_exposure_concentration.py
+++ b/tests/test_risk_exposure_concentration.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+
+def _bootstrap(tmp_path, monkeypatch, *, yaml_text: str) -> None:
+    cfg = tmp_path / "strategy_overrides.yaml"
+    cfg.write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setenv("AI_QUANT_STRATEGY_YAML", str(cfg))
+
+    from engine.strategy_manager import StrategyManager
+
+    StrategyManager.bootstrap(
+        defaults={"trade": {}, "indicators": {}, "filters": {}, "thresholds": {}},
+        yaml_path=str(cfg),
+        changelog_path=None,
+    )
+
+
+def test_exposure_alts_bucket_blocks_new_longs(tmp_path, monkeypatch) -> None:
+    _bootstrap(
+        tmp_path,
+        monkeypatch,
+        yaml_text=(
+            "global:\n"
+            "  risk:\n"
+            "    exposure:\n"
+            "      enabled: true\n"
+            "      alts_max_longs: 2\n"
+            "      alts_max_shorts: 1\n"
+            "      exclude_symbols: [BTC]\n"
+        ),
+    )
+
+    from engine.risk import RiskManager
+
+    risk = RiskManager()
+    risk.refresh(trader=None)
+
+    positions = {
+        "ETH": {"type": "LONG"},
+        "SOL": {"type": "LONG"},
+        "BTC": {"type": "LONG"},  # excluded from alts bucket
+        "ARB": {"type": "SHORT"},
+    }
+
+    # New alt long should be blocked (ETH+SOL already fill the limit).
+    dec = risk.allow_order(
+        symbol="DOGE",
+        action="OPEN",
+        side="BUY",
+        notional_usd=100.0,
+        leverage=1.0,
+        positions=positions,
+        reduce_risk=False,
+    )
+    assert dec.allowed is False
+    assert "exposure_alts_longs" in dec.reason
+
+    # New BTC long should not be blocked by the alts limit.
+    dec2 = risk.allow_order(
+        symbol="BTC",
+        action="OPEN",
+        side="BUY",
+        notional_usd=100.0,
+        leverage=1.0,
+        positions=positions,
+        reduce_risk=False,
+    )
+    assert dec2.allowed is True
+
+    # Adding to an existing position should not be blocked (does not increase exposure count).
+    dec3 = risk.allow_order(
+        symbol="ETH",
+        action="ADD",
+        side="BUY",
+        notional_usd=50.0,
+        leverage=1.0,
+        positions=positions,
+        reduce_risk=False,
+    )
+    assert dec3.allowed is True
+
+
+def test_exposure_alts_bucket_blocks_new_shorts(tmp_path, monkeypatch) -> None:
+    _bootstrap(
+        tmp_path,
+        monkeypatch,
+        yaml_text=(
+            "global:\n"
+            "  risk:\n"
+            "    exposure:\n"
+            "      enabled: true\n"
+            "      alts_max_longs: 99\n"
+            "      alts_max_shorts: 1\n"
+            "      exclude_symbols: [BTC]\n"
+        ),
+    )
+
+    from engine.risk import RiskManager
+
+    risk = RiskManager()
+    risk.refresh(trader=None)
+
+    positions = {
+        "ARB": {"type": "SHORT"},
+    }
+
+    # New alt short should be blocked (already at limit).
+    dec = risk.allow_order(
+        symbol="DOGE",
+        action="OPEN",
+        side="SELL",
+        notional_usd=100.0,
+        leverage=1.0,
+        positions=positions,
+        reduce_risk=False,
+    )
+    assert dec.allowed is False
+    assert "exposure_alts_shorts" in dec.reason
+


### PR DESCRIPTION
Implements a simple exposure concentration guard to cap simultaneous alt longs/shorts.

Changes:
- Adds `global.risk.exposure` config (YAML + env overrides)
- Blocks new entries that would exceed the configured caps (BTC excluded by default)
- Passes current positions into `RiskManager.allow_order()` for best-effort enforcement
- Adds unit tests

Fixes #52