### PR TITLE
AQC-903: Metrics export

### DIFF
--- a/engine/core.py
+++ b/engine/core.py
@@ -1121,6 +1121,31 @@ class UnifiedEngine:
                         kill_reason = str(getattr(risk, "kill_reason", "") or "").strip() or "none"
                     except Exception:
                         kill_reason = "none"
+
+                    slip_enabled = 0
+                    slip_n = 0
+                    slip_win = 0
+                    slip_thr_bps_s = "0"
+                    slip_last_bps_s = "none"
+                    slip_median_bps_s = "none"
+                    try:
+                        fn = getattr(risk, "slippage_guard_stats", None) if risk is not None else None
+                        st = fn() if callable(fn) else {}
+                        if isinstance(st, dict):
+                            slip_enabled = 1 if bool(st.get("enabled")) else 0
+                            slip_n = int(st.get("n") or 0)
+                            slip_win = int(st.get("window_fills") or 0)
+                            thr = st.get("threshold_median_bps")
+                            if thr is not None:
+                                slip_thr_bps_s = f"{float(thr):.3f}"
+                            last = st.get("last_bps")
+                            if last is not None:
+                                slip_last_bps_s = f"{float(last):.3f}"
+                            med = st.get("median_bps")
+                            if med is not None:
+                                slip_median_bps_s = f"{float(med):.3f}"
+                    except Exception:
+                        pass
                     print(
                         f"🫀 engine ok. loops={self.stats.loops} errors={self.stats.loop_errors} "
                         f"symbols={len(active_symbols)} open_pos={open_pos} loop={loop_s:.2f}s "
@@ -1128,6 +1153,8 @@ class UnifiedEngine:
                         f"ws_connected={h.get('connected')} ws_thread_alive={h.get('thread_alive')} "
                         f"ws_restarts={self.stats.ws_restarts} "
                         f"kill={kill_mode} kill_reason={kill_reason} "
+                        f"slip_enabled={slip_enabled} slip_n={slip_n} slip_win={slip_win} slip_thr_bps={slip_thr_bps_s} "
+                        f"slip_last_bps={slip_last_bps_s} slip_median_bps={slip_median_bps_s} "
                         f"signal_on_close={int(self._signal_on_candle_close)} entry_iv={self._entry_interval} exit_iv={self._exit_interval} reanalyze_s={self._reanalyze_interval_s:.0f} exit_reanalyze_s={self._exit_reanalyze_interval_s:.0f} "
                         f"breadth={f'{self._market_breadth_pct:.1f}%' if self._market_breadth_pct is not None else 'n/a'} "
                         f"auto_rev={'ON' if _auto_rev_on else 'OFF'} "

--- a/monitor/heartbeat.py
+++ b/monitor/heartbeat.py
@@ -32,6 +32,12 @@ _HB_WS_RESTARTS_RE = re.compile(r"ws_restarts=([0-9]+)", re.IGNORECASE)
 _HB_KILL_MODE_RE = re.compile(r"kill=(off|close_only|halt_all)", re.IGNORECASE)
 _HB_KILL_REASON_RE = re.compile(r"kill_reason=([^\s]+)", re.IGNORECASE)
 _HB_CONFIG_ID_RE = re.compile(r"config_id=([0-9a-f]{8,64}|none)", re.IGNORECASE)
+_HB_SLIP_ENABLED_RE = re.compile(r"slip_enabled=([01])", re.IGNORECASE)
+_HB_SLIP_N_RE = re.compile(r"slip_n=([0-9]+)", re.IGNORECASE)
+_HB_SLIP_WIN_RE = re.compile(r"slip_win=([0-9]+)", re.IGNORECASE)
+_HB_SLIP_THR_RE = re.compile(r"slip_thr_bps=([0-9.]+)", re.IGNORECASE)
+_HB_SLIP_LAST_RE = re.compile(r"slip_last_bps=([0-9.]+|none)", re.IGNORECASE)
+_HB_SLIP_MED_RE = re.compile(r"slip_median_bps=([0-9.]+|none)", re.IGNORECASE)
 
 
 def connect_db_ro(db_path: Path) -> sqlite3.Connection:
@@ -162,4 +168,27 @@ def parse_last_heartbeat(db_path: Path, log_path: Path) -> dict[str, Any]:
         cid = cid_m.group(1).lower()
         if cid != "none":
             out["config_id"] = cid
+
+    se_m = _HB_SLIP_ENABLED_RE.search(last_line)
+    if se_m:
+        out["slip_enabled"] = se_m.group(1) == "1"
+    sn_m = _HB_SLIP_N_RE.search(last_line)
+    if sn_m:
+        out["slip_n"] = int(sn_m.group(1))
+    sw_m = _HB_SLIP_WIN_RE.search(last_line)
+    if sw_m:
+        out["slip_win"] = int(sw_m.group(1))
+    st_m = _HB_SLIP_THR_RE.search(last_line)
+    if st_m:
+        out["slip_thr_bps"] = float(st_m.group(1))
+    sl_m = _HB_SLIP_LAST_RE.search(last_line)
+    if sl_m:
+        v = sl_m.group(1).lower()
+        if v != "none":
+            out["slip_last_bps"] = float(v)
+    sm_m = _HB_SLIP_MED_RE.search(last_line)
+    if sm_m:
+        v = sm_m.group(1).lower()
+        if v != "none":
+            out["slip_median_bps"] = float(v)
     return out

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -37,7 +37,8 @@ def test_parse_last_heartbeat_text_log_parsing(tmp_path):
     log_path = tmp_path / "engine.log"
     line = (
         "2026-02-09T00:00:00Z 🫀 engine ok wall=1.23s errors=2 symbols=50 open_pos=1 "
-        "ws_connected=True ws_thread_alive=False ws_restarts=3"
+        "ws_connected=True ws_thread_alive=False ws_restarts=3 "
+        "slip_enabled=1 slip_n=3 slip_win=20 slip_thr_bps=5.000 slip_last_bps=10.000 slip_median_bps=7.500"
     )
     log_path.write_text(f"old line\n{line}\n", encoding="utf-8")
     out = hb.parse_last_heartbeat(db_path, log_path)
@@ -50,6 +51,12 @@ def test_parse_last_heartbeat_text_log_parsing(tmp_path):
     assert out["ws_connected"] is True
     assert out["ws_thread_alive"] is False
     assert out["ws_restarts"] == 3
+    assert out["slip_enabled"] is True
+    assert out["slip_n"] == 3
+    assert out["slip_win"] == 20
+    assert out["slip_thr_bps"] == 5.0
+    assert out["slip_last_bps"] == 10.0
+    assert out["slip_median_bps"] == 7.5
 
 
 def test_parse_last_heartbeat_sqlite(tmp_path):


### PR DESCRIPTION
Adds a lightweight metrics export for Grafana/Prometheus via the monitor server.

Changes:
- Adds `/api/metrics` (JSON) and `/metrics` (Prometheus text) to `monitor/server.py`
- Extends engine heartbeat with slippage guard stats for export
- Extends `monitor/heartbeat.py` parsing + tests

Fixes #56