### PR TITLE
AQC-1001: regime gate v1

### DIFF
--- a/config/strategy_overrides.yaml
+++ b/config/strategy_overrides.yaml
@@ -187,6 +187,12 @@ global:
     breadth_block_long_below: 10.0    # default
     auto_reverse_breadth_low: 10.0    # default
     auto_reverse_breadth_high: 90.0   # default
+    enable_regime_gate: false         # default (global entry block when regime is not trend OK)
+    regime_gate_breadth_low: 20.0     # default (inside [low, high] => gate OFF)
+    regime_gate_breadth_high: 80.0    # default
+    regime_gate_btc_adx_min: 20.0     # default
+    regime_gate_btc_atr_pct_min: 0.003 # default
+    regime_gate_fail_open: false      # default (if metrics missing)
 
   watchlist_exclude: []               # engine-only (Rust ignores)
 

--- a/monitor/heartbeat.py
+++ b/monitor/heartbeat.py
@@ -31,6 +31,8 @@ _HB_WS_THREAD_RE = re.compile(r"ws_thread_alive=(True|False)", re.IGNORECASE)
 _HB_WS_RESTARTS_RE = re.compile(r"ws_restarts=([0-9]+)", re.IGNORECASE)
 _HB_KILL_MODE_RE = re.compile(r"kill=(off|close_only|halt_all)", re.IGNORECASE)
 _HB_KILL_REASON_RE = re.compile(r"kill_reason=([^\s]+)", re.IGNORECASE)
+_HB_REGIME_GATE_RE = re.compile(r"regime_gate=(on|off)", re.IGNORECASE)
+_HB_REGIME_REASON_RE = re.compile(r"regime_reason=([^\s]+)", re.IGNORECASE)
 _HB_CONFIG_ID_RE = re.compile(r"config_id=([0-9a-f]{8,64}|none)", re.IGNORECASE)
 _HB_SLIP_ENABLED_RE = re.compile(r"slip_enabled=([01])", re.IGNORECASE)
 _HB_SLIP_N_RE = re.compile(r"slip_n=([0-9]+)", re.IGNORECASE)
@@ -163,6 +165,12 @@ def parse_last_heartbeat(db_path: Path, log_path: Path) -> dict[str, Any]:
     kr_m = _HB_KILL_REASON_RE.search(last_line)
     if kr_m:
         out["kill_reason"] = kr_m.group(1)
+    rg_m = _HB_REGIME_GATE_RE.search(last_line)
+    if rg_m:
+        out["regime_gate"] = rg_m.group(1).lower() == "on"
+    rr_m = _HB_REGIME_REASON_RE.search(last_line)
+    if rr_m:
+        out["regime_reason"] = rr_m.group(1)
     cid_m = _HB_CONFIG_ID_RE.search(last_line)
     if cid_m:
         cid = cid_m.group(1).lower()

--- a/monitor/static/app.js
+++ b/monitor/static/app.js
@@ -1043,6 +1043,33 @@
       }
     }
 
+    // Regime gate (trend OK vs chop).
+    const rgOn = (typeof h.regime_gate === "boolean") ? h.regime_gate : null;
+    const rgReason = String(h.regime_reason || "").trim();
+    const rgPill = $("#regimePill");
+    const rgDot = $("#regimeDot");
+    const rgTxt = $("#regimeTxt");
+    if (rgPill && rgDot && rgTxt) {
+      rgDot.classList.remove("ok", "bad", "warn");
+      rgPill.classList.remove("paused", "running");
+      if (!h.ok) {
+        rgDot.classList.add("warn");
+        rgTxt.textContent = "gate";
+        rgPill.title = "Heartbeat missing; regime gate unknown";
+      } else if (rgOn === null) {
+        rgDot.classList.add("warn");
+        rgTxt.textContent = "gate —";
+        rgPill.title = "Regime gate not reported by engine";
+      } else {
+        rgPill.classList.toggle("running", rgOn);
+        rgPill.classList.toggle("paused", !rgOn);
+        rgDot.classList.toggle("ok", rgOn);
+        rgDot.classList.toggle("bad", !rgOn);
+        rgTxt.textContent = rgOn ? "gate on" : "gate off";
+        rgPill.title = rgOn ? `Regime gate ON (${rgReason || "trend_ok"})` : `Regime gate OFF (${rgReason || "n/a"})`;
+      }
+    }
+
     // Config ID (from engine heartbeat).
     const cfg = String(h.config_id || "").trim();
     const cfgShort = cfg ? cfg.slice(0, 12) : "\u2014";

--- a/monitor/static/index.html
+++ b/monitor/static/index.html
@@ -54,6 +54,11 @@
           <span class="pilltxt" id="stateTxt" aria-live="polite">running</span>
         </div>
 
+        <div class="pill pill-state" id="regimePill" title="Regime gate (trend OK vs chop)">
+          <span class="dot" id="regimeDot"></span>
+          <span class="pilltxt" id="regimeTxt" aria-live="polite">gate</span>
+        </div>
+
         <div class="pill pill-val" id="cfgPill" title="Active config_id (from engine heartbeat)">
           <span class="pillk">cfg</span>
           <span class="pillv" id="cfgId">&mdash;</span>

--- a/strategy/mei_alpha_v1.py
+++ b/strategy/mei_alpha_v1.py
@@ -361,6 +361,13 @@ _DEFAULT_STRATEGY_CONFIG = {
         "enable_auto_reverse": False,
         "auto_reverse_breadth_low": 10.0,
         "auto_reverse_breadth_high": 90.0,
+        # Global regime gate (engine-only): block entries when the regime is not trend OK.
+        "enable_regime_gate": False,
+        "regime_gate_breadth_low": 20.0,
+        "regime_gate_breadth_high": 80.0,
+        "regime_gate_btc_adx_min": 20.0,
+        "regime_gate_btc_atr_pct_min": 0.003,
+        "regime_gate_fail_open": False,
     },
     "watchlist_exclude": [],
     "thresholds": {

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -38,6 +38,7 @@ def test_parse_last_heartbeat_text_log_parsing(tmp_path):
     line = (
         "2026-02-09T00:00:00Z 🫀 engine ok wall=1.23s errors=2 symbols=50 open_pos=1 "
         "ws_connected=True ws_thread_alive=False ws_restarts=3 "
+        "regime_gate=off regime_reason=breadth_chop "
         "slip_enabled=1 slip_n=3 slip_win=20 slip_thr_bps=5.000 slip_last_bps=10.000 slip_median_bps=7.500"
     )
     log_path.write_text(f"old line\n{line}\n", encoding="utf-8")
@@ -51,6 +52,8 @@ def test_parse_last_heartbeat_text_log_parsing(tmp_path):
     assert out["ws_connected"] is True
     assert out["ws_thread_alive"] is False
     assert out["ws_restarts"] == 3
+    assert out["regime_gate"] is False
+    assert out["regime_reason"] == "breadth_chop"
     assert out["slip_enabled"] is True
     assert out["slip_n"] == 3
     assert out["slip_win"] == 20
@@ -96,6 +99,7 @@ def test_parse_last_heartbeat_parses_kill_and_config_id(tmp_path):
         "2026-02-09T00:00:00Z 🫀 engine ok loop=0.25s errors=0 symbols=3 open_pos=0 "
         "ws_connected=False ws_thread_alive=True ws_restarts=0 "
         "kill=close_only kill_reason=drawdown "
+        "regime_gate=on regime_reason=trend_ok "
         f"config_id={cid}"
     )
     log_path.write_text(f"{line}\n", encoding="utf-8")
@@ -103,6 +107,8 @@ def test_parse_last_heartbeat_parses_kill_and_config_id(tmp_path):
     assert out["ok"] is True
     assert out["kill_mode"] == "close_only"
     assert out["kill_reason"] == "drawdown"
+    assert out["regime_gate"] is True
+    assert out["regime_reason"] == "trend_ok"
     assert out["config_id"] == cid
 
 


### PR DESCRIPTION
Fixes #59

- Add a global regime gate computed once per main bar from market breadth + BTC ADX/ATR%.
- Block entries when the gate is OFF (exits still run) and log state changes via audit events.
- Expose gate state in the engine heartbeat and show it in the monitor dashboard.