### PR TITLE
AQC-1002: mode switching policy

### DIFF
--- a/config/strategy_overrides.yaml
+++ b/config/strategy_overrides.yaml
@@ -203,5 +203,37 @@ global:
     loop_target_s: 60
     signal_on_candle_close: true
 
+# Optional strategy-mode overlays (AQC-1002).
+# Enable by setting AI_QUANT_STRATEGY_MODE=primary|fallback|conservative|flat.
+#
+# Notes:
+# - Changing global.engine.interval requires a restart (engine.interval is not hot-reloadable).
+# - entry_interval / exit_interval are hot-reloadable.
+modes:
+  primary:
+    global:
+      engine:
+        interval: 30m
+        entry_interval: 5m
+        exit_interval: 5m
+  fallback:
+    global:
+      engine:
+        interval: 1h
+        entry_interval: 5m
+        exit_interval: 5m
+  conservative:
+    global:
+      engine:
+        interval: 1h
+        entry_interval: 15m
+        exit_interval: 15m
+  flat:
+    global:
+      engine:
+        interval: 1h
+        entry_interval: 15m
+        exit_interval: 15m
+
 # No `live:` section — live engine uses identical global config as backtester.
 # What you replay = what you trade.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -83,6 +83,40 @@ journalctl --user -u openclaw-ai-quant-live --since "10 min ago" | grep -i kill
 
 ---
 
+## 1b. Strategy Mode Switching (AQC-1002)
+
+The engine supports an optional strategy-mode overlay selected via `AI_QUANT_STRATEGY_MODE`:
+
+- `primary`: 30m/5m
+- `fallback`: 1h/5m
+- `conservative`: 1h/15m
+- `flat`: safety profile (use with a kill-switch when needed)
+
+Mode overlays are defined under `modes:` in `config/strategy_overrides.yaml`.
+
+### Manual mode change
+
+```bash
+export AI_QUANT_STRATEGY_MODE=fallback
+
+# Restart is required if the mode changes global.engine.interval.
+systemctl --user restart openclaw-ai-quant-live
+```
+
+### Automatic step-down on kill events
+
+When enabled (`AI_QUANT_MODE_SWITCH_ENABLE=1`), the live daemon steps down one mode on each new kill event
+and persists the selected mode to `AI_QUANT_STRATEGY_MODE_FILE` (default: `artifacts/state/strategy_mode.txt`).
+
+If your systemd unit is configured to auto-restart on exit, you can also enable:
+
+- `AI_QUANT_MODE_SWITCH_EXIT_ON_RESTART_REQUIRED=1`
+
+This makes the daemon exit when switching to/from `primary` (where an interval change is likely), allowing
+systemd to restart it with the new persisted mode.
+
+---
+
 ## 2. Roll Back Config
 
 Use when: a bad config was deployed and needs to be reverted to last-known-good.

--- a/engine/core.py
+++ b/engine/core.py
@@ -1318,6 +1318,11 @@ class UnifiedEngine:
                     except Exception:
                         kill_reason = "none"
 
+                    try:
+                        strategy_mode = str(os.getenv("AI_QUANT_STRATEGY_MODE", "") or "").strip().lower() or "none"
+                    except Exception:
+                        strategy_mode = "none"
+
                     slip_enabled = 0
                     slip_n = 0
                     slip_win = 0
@@ -1349,6 +1354,7 @@ class UnifiedEngine:
                         f"ws_connected={h.get('connected')} ws_thread_alive={h.get('thread_alive')} "
                         f"ws_restarts={self.stats.ws_restarts} "
                         f"kill={kill_mode} kill_reason={kill_reason} "
+                        f"strategy_mode={strategy_mode} "
                         f"regime_gate={'on' if self._regime_gate_on else 'off'} regime_reason={self._regime_gate_reason} "
                         f"slip_enabled={slip_enabled} slip_n={slip_n} slip_win={slip_win} slip_thr_bps={slip_thr_bps_s} "
                         f"slip_last_bps={slip_last_bps_s} slip_median_bps={slip_median_bps_s} "

--- a/engine/daemon.py
+++ b/engine/daemon.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 import time
 from collections import deque
+from pathlib import Path
 
 from .core import UnifiedEngine
 from .market_data import MarketDataHub
@@ -40,6 +41,153 @@ def _env_bool(name: str, default: bool = False) -> bool:
 
 def _mode() -> str:
     return str(os.getenv("AI_QUANT_MODE", "paper") or "paper").strip().lower()
+
+
+def _norm_strategy_mode(raw: str) -> str:
+    s = str(raw or "").strip().lower()
+    if not s:
+        return ""
+    if s in {"mode1", "m1"}:
+        return "primary"
+    if s in {"mode2", "m2"}:
+        return "fallback"
+    if s in {"mode3", "m3", "safety", "safe"}:
+        return "conservative"
+    if s in {"halt", "pause", "paused"}:
+        return "flat"
+    return s
+
+
+def _strategy_mode_file() -> Path:
+    p = str(os.getenv("AI_QUANT_STRATEGY_MODE_FILE", "") or "").strip()
+    if p:
+        return Path(p).expanduser().resolve()
+    root = Path(__file__).resolve().parents[1]
+    return (root / "artifacts" / "state" / "strategy_mode.txt").resolve()
+
+
+def _read_strategy_mode_file(path: Path) -> str:
+    try:
+        if not path.exists():
+            return ""
+        return _norm_strategy_mode(path.read_text(encoding="utf-8").strip())
+    except Exception:
+        return ""
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    tmp.write_text(str(text), encoding="utf-8")
+    os.replace(str(tmp), str(path))
+
+
+class StrategyModePolicy:
+    """Automatic strategy-mode switching (Primary/Fallback/Conservative/Flat).
+
+    This policy is intentionally conservative:
+    - It only steps down (no automatic step-up).
+    - It triggers on new kill events (kill_since_s changes).
+    - It persists the selected mode to a local file so restarts can pick it up.
+    """
+
+    _ORDER = ["primary", "fallback", "conservative", "flat"]
+
+    def __init__(self, *, risk: RiskManager | None):
+        self._risk = risk
+        self._enabled = _env_bool("AI_QUANT_MODE_SWITCH_ENABLE", False)
+        self._exit_on_restart_required = _env_bool("AI_QUANT_MODE_SWITCH_EXIT_ON_RESTART_REQUIRED", False)
+        self._mode_file = _strategy_mode_file()
+        self._last_handled_kill_since_s: float | None = None
+        self._last_switch_s: float = 0.0
+        try:
+            self._cooldown_s = float(os.getenv("AI_QUANT_MODE_SWITCH_COOLDOWN_S", "0") or 0)
+        except Exception:
+            self._cooldown_s = 0.0
+
+    def _current_mode(self) -> str:
+        cur = _norm_strategy_mode(str(os.getenv("AI_QUANT_STRATEGY_MODE", "") or ""))
+        if cur:
+            return cur
+        # If env is not set, fall back to the persisted file (if present).
+        return _read_strategy_mode_file(self._mode_file) or "primary"
+
+    def _step_down(self, cur: str) -> str:
+        cur = _norm_strategy_mode(cur) or "primary"
+        if cur not in self._ORDER:
+            cur = "primary"
+        i = self._ORDER.index(cur)
+        return self._ORDER[min(i + 1, len(self._ORDER) - 1)]
+
+    def maybe_switch(self) -> None:
+        if not self._enabled:
+            return
+        r = self._risk
+        if r is None:
+            return
+
+        km = str(getattr(r, "kill_mode", "off") or "off").strip().lower()
+        if km == "off":
+            return
+        kr = str(getattr(r, "kill_reason", "") or "").strip() or "none"
+        ks = getattr(r, "kill_since_s", None)
+        try:
+            ks = None if ks is None else float(ks)
+        except Exception:
+            ks = None
+        if ks is None:
+            return
+
+        if self._last_handled_kill_since_s is not None and float(ks) == float(self._last_handled_kill_since_s):
+            return
+
+        now_s = time.time()
+        if self._cooldown_s > 0 and (now_s - float(self._last_switch_s or 0.0)) < float(self._cooldown_s):
+            # Suppress rapid-fire switches, but mark the kill as handled to avoid log spam.
+            self._last_handled_kill_since_s = float(ks)
+            return
+
+        cur = self._current_mode()
+        # v1 policy: always step down on a new kill event.
+        target = self._step_down(cur)
+        self._last_handled_kill_since_s = float(ks)
+
+        if target == cur:
+            return
+
+        os.environ["AI_QUANT_STRATEGY_MODE"] = str(target)
+        try:
+            _atomic_write_text(self._mode_file, str(target) + "\n")
+        except Exception:
+            pass
+
+        self._last_switch_s = now_s
+
+        # Log as a structured event (best-effort).
+        try:
+            from .event_logger import emit_event
+
+            emit_event(
+                kind="MODE_SWITCH",
+                data={
+                    "from": str(cur),
+                    "to": str(target),
+                    "trigger": "risk_kill",
+                    "kill_mode": str(km),
+                    "kill_reason": str(kr),
+                    "kill_since_s": float(ks),
+                    "restart_required": bool(cur == "primary" or target == "primary"),
+                },
+            )
+        except Exception:
+            pass
+
+        print(f"🧭 mode switch: {cur} -> {target} (kill={km} reason={kr})")
+
+        if bool(self._exit_on_restart_required) and bool(cur == "primary" or target == "primary"):
+            raise SystemExit(f"Mode switch requires restart (interval change likely): {cur} -> {target}")
+
 
 def _default_db_path() -> str:
     try:
@@ -266,6 +414,9 @@ class LivePlugin:
             self._max_entry_orders_per_loop = 6
         self._max_entry_orders_per_loop = max(0, int(self._max_entry_orders_per_loop))
 
+        # Automatic strategy-mode switching (best-effort).
+        self._mode_policy = StrategyModePolicy(risk=self._risk)
+
     def _log_exc(self, key: str, msg: str) -> None:
         now = time.time()
         last = float(self._err_last_s.get(key, 0.0) or 0.0)
@@ -480,11 +631,19 @@ class LivePlugin:
                 self._log_exc("risk_reduce_drawdown", "reduce-risk on drawdown kill failed")
 
             # Periodic OMS maintenance (expire stale intents).
-            try:
-                if self._oms is not None:
-                    self._oms.reconcile(trader=self.trader)
-            except Exception:
-                self._log_exc("oms_reconcile", "OMS reconcile() failed")
+                try:
+                    if self._oms is not None:
+                        self._oms.reconcile(trader=self.trader)
+                except Exception:
+                    self._log_exc("oms_reconcile", "OMS reconcile() failed")
+
+        # Mode switching policy (runs after risk.refresh so new kill events are visible).
+        try:
+            self._mode_policy.maybe_switch()
+        except SystemExit:
+            raise
+        except Exception:
+            pass
 
         # True OMS reconcile loop (open orders, stale cancels, partial-fill tidy).
         try:
@@ -729,6 +888,15 @@ def main() -> None:
         os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", default_lock_name),
     )
     _lock = acquire_lock_or_exit(lock_path)
+
+    # If a strategy mode is persisted locally, load it on startup (only when env is unset).
+    try:
+        if not str(os.getenv("AI_QUANT_STRATEGY_MODE", "") or "").strip():
+            m = _read_strategy_mode_file(_strategy_mode_file())
+            if m:
+                os.environ["AI_QUANT_STRATEGY_MODE"] = str(m)
+    except Exception:
+        pass
 
     strategy = StrategyManager.get()
     market_db_path = os.getenv("AI_QUANT_MARKET_DB_PATH", mei_alpha_v1.DB_PATH)

--- a/monitor/heartbeat.py
+++ b/monitor/heartbeat.py
@@ -31,6 +31,7 @@ _HB_WS_THREAD_RE = re.compile(r"ws_thread_alive=(True|False)", re.IGNORECASE)
 _HB_WS_RESTARTS_RE = re.compile(r"ws_restarts=([0-9]+)", re.IGNORECASE)
 _HB_KILL_MODE_RE = re.compile(r"kill=(off|close_only|halt_all)", re.IGNORECASE)
 _HB_KILL_REASON_RE = re.compile(r"kill_reason=([^\s]+)", re.IGNORECASE)
+_HB_STRATEGY_MODE_RE = re.compile(r"strategy_mode=([^\s]+)", re.IGNORECASE)
 _HB_REGIME_GATE_RE = re.compile(r"regime_gate=(on|off)", re.IGNORECASE)
 _HB_REGIME_REASON_RE = re.compile(r"regime_reason=([^\s]+)", re.IGNORECASE)
 _HB_CONFIG_ID_RE = re.compile(r"config_id=([0-9a-f]{8,64}|none)", re.IGNORECASE)
@@ -165,6 +166,9 @@ def parse_last_heartbeat(db_path: Path, log_path: Path) -> dict[str, Any]:
     kr_m = _HB_KILL_REASON_RE.search(last_line)
     if kr_m:
         out["kill_reason"] = kr_m.group(1)
+    smod_m = _HB_STRATEGY_MODE_RE.search(last_line)
+    if smod_m:
+        out["strategy_mode"] = smod_m.group(1).lower()
     rg_m = _HB_REGIME_GATE_RE.search(last_line)
     if rg_m:
         out["regime_gate"] = rg_m.group(1).lower() == "on"

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -38,6 +38,7 @@ def test_parse_last_heartbeat_text_log_parsing(tmp_path):
     line = (
         "2026-02-09T00:00:00Z 🫀 engine ok wall=1.23s errors=2 symbols=50 open_pos=1 "
         "ws_connected=True ws_thread_alive=False ws_restarts=3 "
+        "strategy_mode=fallback "
         "regime_gate=off regime_reason=breadth_chop "
         "slip_enabled=1 slip_n=3 slip_win=20 slip_thr_bps=5.000 slip_last_bps=10.000 slip_median_bps=7.500"
     )
@@ -52,6 +53,7 @@ def test_parse_last_heartbeat_text_log_parsing(tmp_path):
     assert out["ws_connected"] is True
     assert out["ws_thread_alive"] is False
     assert out["ws_restarts"] == 3
+    assert out["strategy_mode"] == "fallback"
     assert out["regime_gate"] is False
     assert out["regime_reason"] == "breadth_chop"
     assert out["slip_enabled"] is True
@@ -99,6 +101,7 @@ def test_parse_last_heartbeat_parses_kill_and_config_id(tmp_path):
         "2026-02-09T00:00:00Z 🫀 engine ok loop=0.25s errors=0 symbols=3 open_pos=0 "
         "ws_connected=False ws_thread_alive=True ws_restarts=0 "
         "kill=close_only kill_reason=drawdown "
+        "strategy_mode=primary "
         "regime_gate=on regime_reason=trend_ok "
         f"config_id={cid}"
     )
@@ -107,6 +110,7 @@ def test_parse_last_heartbeat_parses_kill_and_config_id(tmp_path):
     assert out["ok"] is True
     assert out["kill_mode"] == "close_only"
     assert out["kill_reason"] == "drawdown"
+    assert out["strategy_mode"] == "primary"
     assert out["regime_gate"] is True
     assert out["regime_reason"] == "trend_ok"
     assert out["config_id"] == cid


### PR DESCRIPTION
Fixes #60

- Add optional `modes:` overlays in strategy YAML, selected via `AI_QUANT_STRATEGY_MODE`.
- Implement a conservative step-down policy on new risk kill events (persisted to a local mode file).
- Expose `strategy_mode` in the engine heartbeat for observability.