### PR TITLE
AQC-1104: system service management

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -13,6 +13,30 @@ Procedures for common operational scenarios. When the bot misbehaves, follow the
 
 All services are systemd user units. Manage with `systemctl --user <action> <unit>`.
 
+### Optional timers (nightly factory + log pruning)
+
+Example service/timer templates live under `systemd/`:
+
+- `openclaw-ai-quant-factory.{service,timer}.example` runs `factory_run.py` nightly.
+- `openclaw-ai-quant-prune-runtime-logs.{service,timer}.example` prunes SQLite `runtime_logs` daily.
+
+Install (example):
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp systemd/openclaw-ai-quant-factory.* ~/.config/systemd/user/
+cp systemd/openclaw-ai-quant-prune-runtime-logs.* ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now openclaw-ai-quant-factory.timer
+systemctl --user enable --now openclaw-ai-quant-prune-runtime-logs.timer
+```
+
+Configure runtime log retention via:
+
+```
+AI_QUANT_RUNTIME_LOG_KEEP_DAYS=14
+```
+
 ---
 
 ## 1. Pause Trading (Emergency Stop)

--- a/systemd/openclaw-ai-quant-factory.service.example
+++ b/systemd/openclaw-ai-quant-factory.service.example
@@ -1,0 +1,16 @@
+[Unit]
+Description=OpenClaw AI Quant Nightly Strategy Factory Run
+After=network-online.target openclaw-ai-quant-ws-sidecar.service
+Wants=network-online.target
+Requires=openclaw-ai-quant-ws-sidecar.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=$PROJECT_DIR
+EnvironmentFile=-%h/.config/openclaw/ai-quant-universe.env
+EnvironmentFile=-%h/.config/openclaw/ai-quant-live.env
+ExecStart=/usr/bin/env bash -lc "cd \"$PROJECT_DIR\" && \"$PROJECT_DIR/.venv/bin/python3\" -u factory_run.py --run-id nightly_$(date -u +%Y%m%dT%H%M%SZ) --profile daily"
+
+[Install]
+WantedBy=default.target
+

--- a/systemd/openclaw-ai-quant-factory.timer.example
+++ b/systemd/openclaw-ai-quant-factory.timer.example
@@ -1,0 +1,11 @@
+[Unit]
+Description=OpenClaw AI Quant Nightly Strategy Factory Timer
+
+[Timer]
+OnCalendar=*-*-* 00:30:00 UTC
+Persistent=true
+Unit=openclaw-ai-quant-factory.service
+
+[Install]
+WantedBy=timers.target
+

--- a/systemd/openclaw-ai-quant-prune-runtime-logs.service.example
+++ b/systemd/openclaw-ai-quant-prune-runtime-logs.service.example
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenClaw AI Quant Prune Runtime Logs (SQLite)
+
+[Service]
+Type=oneshot
+WorkingDirectory=$PROJECT_DIR
+EnvironmentFile=-%h/.config/openclaw/ai-quant-live.env
+ExecStart=$PROJECT_DIR/.venv/bin/python3 -u tools/prune_runtime_logs.py
+
+[Install]
+WantedBy=default.target
+

--- a/systemd/openclaw-ai-quant-prune-runtime-logs.timer.example
+++ b/systemd/openclaw-ai-quant-prune-runtime-logs.timer.example
@@ -1,0 +1,11 @@
+[Unit]
+Description=OpenClaw AI Quant Prune Runtime Logs Timer
+
+[Timer]
+OnCalendar=*-*-* 01:15:00 UTC
+Persistent=true
+Unit=openclaw-ai-quant-prune-runtime-logs.service
+
+[Install]
+WantedBy=timers.target
+

--- a/tools/prune_runtime_logs.py
+++ b/tools/prune_runtime_logs.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Prune SQLite runtime logs to a bounded retention window (AQC-1104).
+
+The engine can optionally mirror stdout/stderr into the `runtime_logs` table via
+`engine.sqlite_logger`. This table is useful for dashboards and debugging, but it
+will grow without bound if left unattended.
+
+This tool deletes rows older than N days (UTC) and is designed to run from a
+systemd timer or cron job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+
+AIQ_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _default_db_path() -> Path:
+    return (AIQ_ROOT / "trading_engine.db").resolve()
+
+
+def _db_path() -> Path:
+    p = str(os.getenv("AI_QUANT_DB_PATH", "") or "").strip()
+    return Path(p).expanduser().resolve() if p else _default_db_path()
+
+
+def _table_exists(con: sqlite3.Connection, name: str) -> bool:
+    row = con.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1",
+        (str(name),),
+    ).fetchone()
+    return row is not None
+
+
+def prune_runtime_logs(*, db_path: Path, keep_days: float, dry_run: bool, vacuum: bool) -> int:
+    db_path = Path(db_path).expanduser().resolve()
+    if not db_path.exists():
+        # Nothing to do.
+        return 0
+
+    keep_s = float(max(0.0, float(keep_days))) * 86400.0
+    cutoff_ts_ms = int((time.time() - keep_s) * 1000.0)
+
+    con = sqlite3.connect(str(db_path), timeout=2.0)
+    try:
+        if not _table_exists(con, "runtime_logs"):
+            return 0
+
+        row = con.execute("SELECT COUNT(*) FROM runtime_logs WHERE ts_ms < ?", (int(cutoff_ts_ms),)).fetchone()
+        n = int(row[0] if row else 0)
+        if n <= 0:
+            return 0
+
+        if dry_run:
+            print(f"[prune_runtime_logs] would_delete={n} cutoff_ts_ms={cutoff_ts_ms} db={db_path}")
+            return 0
+
+        con.execute("DELETE FROM runtime_logs WHERE ts_ms < ?", (int(cutoff_ts_ms),))
+        con.commit()
+        print(f"[prune_runtime_logs] deleted={n} cutoff_ts_ms={cutoff_ts_ms} db={db_path}")
+
+        if vacuum:
+            # VACUUM can be expensive; keep it opt-in.
+            con.execute("VACUUM")
+            con.commit()
+        return 0
+    finally:
+        con.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Prune runtime_logs rows older than N days.")
+    ap.add_argument("--db", default="", help="SQLite DB path (default: AI_QUANT_DB_PATH or ./trading_engine.db).")
+    ap.add_argument(
+        "--keep-days",
+        type=float,
+        default=float(os.getenv("AI_QUANT_RUNTIME_LOG_KEEP_DAYS", "14") or 14),
+        help="Retention window in days (default: 14).",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="Print what would be deleted without writing.")
+    ap.add_argument("--vacuum", action="store_true", help="Run VACUUM after deleting rows (slow).")
+    args = ap.parse_args(argv)
+
+    path = Path(str(args.db)).expanduser().resolve() if str(args.db).strip() else _db_path()
+    return int(
+        prune_runtime_logs(
+            db_path=path,
+            keep_days=float(args.keep_days),
+            dry_run=bool(args.dry_run),
+            vacuum=bool(args.vacuum),
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Fixes #66

- Add example systemd timer units for nightly factory runs.
- Add runtime log retention via a prune tool + daily timer template.
- Document installation and retention settings in the runbook.