### PR TITLE
AQC-1103: backtester build stamping

### DIFF
--- a/backtester/README.md
+++ b/backtester/README.md
@@ -5,9 +5,17 @@ High-performance Rust backtesting simulator for the Mei Alpha strategy.
 ## Build
 
 ```bash
-cd workspace/dev/ai_quant/backtester
-cargo build --release
-# Binary: target/release/mei-backtester
+# From the repo root
+python3 tools/build_mei_backtester.py
+
+# Optional GPU build (requires CUDA toolchain)
+python3 tools/build_mei_backtester.py --gpu
+```
+
+The binary is version-stamped at build time and supports:
+
+```bash
+mei-backtester --version
 ```
 
 ## Commands

--- a/backtester/crates/bt-cli/Cargo.toml
+++ b/backtester/crates/bt-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bt-cli"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [[bin]]
 name = "mei-backtester"

--- a/backtester/crates/bt-cli/build.rs
+++ b/backtester/crates/bt-cli/build.rs
@@ -1,0 +1,53 @@
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn _git_sha() -> String {
+    if let Ok(sha) = std::env::var("GITHUB_SHA") {
+        let s = sha.trim();
+        if !s.is_empty() {
+            return s.chars().take(12).collect();
+        }
+    }
+
+    // Best-effort local build: derive from git.
+    let out = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output();
+    if let Ok(out) = out {
+        if out.status.success() {
+            let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !s.is_empty() {
+                return s;
+            }
+        }
+    }
+    "unknown".to_string()
+}
+
+fn _build_unix_s() -> u64 {
+    if let Ok(v) = std::env::var("SOURCE_DATE_EPOCH") {
+        if let Ok(x) = v.trim().parse::<u64>() {
+            return x;
+        }
+    }
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn main() {
+    let sha = _git_sha();
+    println!("cargo:rustc-env=AIQ_GIT_SHA={sha}");
+
+    let build_unix = _build_unix_s();
+    println!("cargo:rustc-env=AIQ_BUILD_UNIX={build_unix}");
+
+    let gpu = if std::env::var_os("CARGO_FEATURE_GPU").is_some() { "1" } else { "0" };
+    println!("cargo:rustc-env=AIQ_GPU={gpu}");
+
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_GPU");
+}
+

--- a/backtester/crates/bt-cli/src/main.rs
+++ b/backtester/crates/bt-cli/src/main.rs
@@ -14,7 +14,15 @@ use std::time::Instant;
 use chrono::{DateTime, NaiveDate, SecondsFormat, Utc};
 use clap::{Parser, Subcommand};
 
-const VERSION: &str = "0.1.0";
+const VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " git:",
+    env!("AIQ_GIT_SHA"),
+    " build:",
+    env!("AIQ_BUILD_UNIX"),
+    " gpu:",
+    env!("AIQ_GPU")
+);
 const DEFAULT_LOOKBACK: usize = 200;
 
 #[derive(Clone, Copy, Debug)]
@@ -2329,10 +2337,10 @@ mod guardrails_tests {
 // ---------------------------------------------------------------------------
 
 fn main() {
+    let cli = Cli::parse();
+
     eprintln!("mei-backtester v{VERSION}");
     eprintln!();
-
-    let cli = Cli::parse();
 
     let result = match cli.command {
         Commands::Replay(args) => cmd_replay(args),

--- a/tools/build_mei_backtester.py
+++ b/tools/build_mei_backtester.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Build stamped mei-backtester binaries (CPU and optional GPU) (AQC-1103).
+
+This is a small automation wrapper around cargo build that:
+- builds a release binary without GPU features (CPU build)
+- optionally builds a GPU-featured release binary
+- copies the resulting artefacts into backtester/dist/
+- writes a build_info.json summary for traceability
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+AIQ_ROOT = Path(__file__).resolve().parents[1]
+BT_ROOT = (AIQ_ROOT / "backtester").resolve()
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _run(argv: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _git_head() -> str:
+    try:
+        out = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=str(AIQ_ROOT)).decode("utf-8").strip()
+        return out
+    except Exception:
+        return ""
+
+
+def _target_bin_path() -> Path:
+    exe = "mei-backtester.exe" if os.name == "nt" else "mei-backtester"
+    return (BT_ROOT / "target" / "release" / exe).resolve()
+
+
+@dataclass(frozen=True)
+class BuiltArtefact:
+    kind: str  # cpu | gpu
+    path: str
+    sha256: str
+    version: str
+
+
+def _read_version(path: Path) -> str:
+    proc = _run([str(path), "--version"], cwd=BT_ROOT)
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        raise RuntimeError(f"--version failed (exit={proc.returncode}): {stderr}")
+    return (proc.stdout or "").strip()
+
+
+def _build_one(*, kind: str, features: list[str]) -> BuiltArtefact:
+    argv = ["cargo", "build", "--release", "-p", "bt-cli", "--bin", "mei-backtester"]
+    if features:
+        argv += ["--features", ",".join(features)]
+
+    proc = _run(argv, cwd=BT_ROOT)
+    if proc.returncode != 0:
+        raise SystemExit(
+            "cargo build failed:\n"
+            + (proc.stdout or "")
+            + "\n"
+            + (proc.stderr or "")
+        )
+
+    bin_path = _target_bin_path()
+    if not bin_path.exists():
+        raise SystemExit(f"Expected binary not found after build: {bin_path}")
+
+    version = _read_version(bin_path)
+    return BuiltArtefact(kind=str(kind), path=str(bin_path), sha256=_sha256(bin_path), version=version)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Build mei-backtester CPU/GPU binaries and stamp build metadata.")
+    ap.add_argument("--out-dir", default=str(BT_ROOT / "dist"), help="Output directory (default: backtester/dist).")
+    ap.add_argument("--gpu", action="store_true", help="Also build the GPU-featured binary.")
+    args = ap.parse_args(argv)
+
+    out_dir = Path(str(args.out_dir)).expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    started = int(time.time() * 1000)
+    artefacts: list[BuiltArtefact] = []
+
+    # CPU build first, copy out before the GPU build overwrites the target binary.
+    cpu = _build_one(kind="cpu", features=[])
+    cpu_dst = (out_dir / ("mei-backtester-cpu.exe" if os.name == "nt" else "mei-backtester-cpu")).resolve()
+    shutil.copy2(Path(cpu.path), cpu_dst)
+    artefacts.append(BuiltArtefact(kind="cpu", path=str(cpu_dst), sha256=_sha256(cpu_dst), version=cpu.version))
+
+    if bool(args.gpu):
+        gpu = _build_one(kind="gpu", features=["gpu"])
+        gpu_dst = (out_dir / ("mei-backtester-gpu.exe" if os.name == "nt" else "mei-backtester-gpu")).resolve()
+        shutil.copy2(Path(gpu.path), gpu_dst)
+        artefacts.append(BuiltArtefact(kind="gpu", path=str(gpu_dst), sha256=_sha256(gpu_dst), version=gpu.version))
+
+    meta: dict[str, Any] = {
+        "version": "mei_backtester_build_v1",
+        "generated_at_ms": started,
+        "git_head": _git_head(),
+        "artefacts": [a.__dict__ for a in artefacts],
+    }
+    (out_dir / "build_info.json").write_text(json.dumps(meta, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    sys.stdout.write(json.dumps(meta, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Fixes #65

- Stamp mei-backtester version with git SHA, build epoch, and gpu feature flag at build time.
- Record mei-backtester --version output in factory run_metadata for traceability.
- Add a small build helper to produce CPU/GPU artefacts under backtester/dist/.