### PR TITLE
AQC-1105: secrets management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,16 @@ AI_QUANT_DISCORD_CHANNEL=
 # Discord channel ID for live trade notifications (optional).
 # AI_QUANT_DISCORD_CHANNEL_LIVE=
 
+# Alerting (AQC-904): uses `openclaw message send` to deliver notifications.
+# IMPORTANT: Some targets (e.g. webhook URLs) are secrets. Store them in your systemd EnvironmentFile,
+# not in the repo. The alerting code redacts targets in logs, but do not rely on that as your only safeguard.
+#
+# Format: comma-separated channel:target pairs.
+# Examples:
+# AI_QUANT_ALERT_TARGETS=discord:#alerts,telegram:@my_alerts
+# AI_QUANT_ALERT_ENABLED=1
+# AI_QUANT_ALERT_DRY_RUN=1
+
 # ── Live Safety Gates ─────────────────────────────────────────────
 # Both must be set for live mode to send real orders.
 # AI_QUANT_LIVE_ENABLE=1

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -37,6 +37,14 @@ Configure runtime log retention via:
 AI_QUANT_RUNTIME_LOG_KEEP_DAYS=14
 ```
 
+### Secrets management
+
+Do not store secrets in the repo. Recommended locations:
+
+- Hyperliquid key material: `~/.config/openclaw/ai-quant-secrets.json` (chmod 600)
+- Service environment: `~/.config/openclaw/ai-quant-live.env`
+  - Put alerting targets (e.g. `AI_QUANT_ALERT_TARGETS`) here, especially if using webhook URLs.
+
 ---
 
 ## 1. Pause Trading (Emergency Stop)


### PR DESCRIPTION
Fixes #67

- Document where to store secrets (env files + secrets.json outside the repo).
- Add alerting env var examples and warnings to .env.example/runbook.
- Redact alert targets in logs to reduce accidental secret exposure.