### PR TITLE
AQC-1004: Research pipeline scaffold for new strategy modules

### DIFF
--- a/research/strategy_modules/README.md
+++ b/research/strategy_modules/README.md
@@ -1,0 +1,24 @@
+# Strategy Modules (Research Pipeline) (AQC-1004)
+
+A **strategy module** is a self-contained directory that can be plugged into the existing factory workflow:
+
+- GPU sweep (optional) via `mei-backtester sweep`
+- CPU replay via `mei-backtester replay`
+- Validation suite via the existing `tools/*.py` validators
+- Reporting and artefact capture via `factory_run.py`
+
+The intention is to make it easy to prototype new strategy archetypes (mean reversion, funding arb, etc.)
+without changing the factory code-paths.
+
+## What A Module Contains
+
+- `strategy.yaml`: the base strategy config (YAML overlay).
+- `sweep.yaml`: a sweep spec for GPU/CPU parameter search.
+- `README.md`: module-specific notes and repro commands.
+
+## Template
+
+Start from:
+
+- `research/strategy_modules/template/`
+

--- a/research/strategy_modules/template/README.md
+++ b/research/strategy_modules/template/README.md
@@ -1,0 +1,34 @@
+# Strategy Module Template (AQC-1004)
+
+This is a minimal template for creating a new strategy module that works with the current factory pipeline.
+
+## 1. Validate The Config
+
+```bash
+python tools/deploy_validate.py --config research/strategy_modules/template/strategy.yaml
+```
+
+## 2. Run A Factory Smoke Profile
+
+This runs the end-to-end pipeline and stores artefacts under `artifacts/<run_id>/`.
+
+```bash
+python factory_run.py \
+  --run-id template_smoke_$(date +%Y%m%d_%H%M%S) \
+  --profile smoke \
+  --config research/strategy_modules/template/strategy.yaml \
+  --sweep-spec research/strategy_modules/template/sweep.yaml
+```
+
+To use the GPU sweep path, add `--gpu` (requires CUDA build/runtime and an idle GPU).
+
+## 3. Validation Suite Hooks
+
+The factory pipeline already supports running additional validators. For manual validation runs, you can use:
+
+- `tools/sensitivity_check.py` (one-at-a-time parameter perturbations)
+- `tools/cross_universe_validate.py` (robustness across symbol universes)
+- `tools/monte_carlo_bootstrap.py` (bootstrap resampling)
+
+Each tool accepts `--config <path>` and produces machine-readable JSON outputs for gating.
+

--- a/research/strategy_modules/template/strategy.yaml
+++ b/research/strategy_modules/template/strategy.yaml
@@ -1,0 +1,33 @@
+# Strategy module template config.
+#
+# This file is intentionally minimal, but it includes the fields required by
+# `tools/deploy_validate.py`. Missing keys fall back to engine/backtester defaults.
+global:
+  trade:
+    allocation_pct: 0.03
+    leverage: 3.0
+    sl_atr_mult: 2.0
+    tp_atr_mult: 4.0
+    slippage_bps: 10.0
+    max_open_positions: 20
+    max_total_margin_pct: 0.60
+    min_notional_usd: 10.0
+    min_atr_pct: 0.003
+    bump_to_min_notional: false
+
+  indicators:
+    adx_window: 14
+    ema_fast_window: 20
+    ema_slow_window: 50
+    bb_window: 20
+    atr_window: 14
+
+  thresholds:
+    entry:
+      min_adx: 22.0
+
+  engine:
+    interval: 1h
+    entry_interval: 5m
+    exit_interval: 5m
+

--- a/research/strategy_modules/template/sweep.yaml
+++ b/research/strategy_modules/template/sweep.yaml
@@ -1,0 +1,14 @@
+# Template sweep spec.
+#
+# Keep this small until the module is stable. Scale axes later.
+axes:
+  - path: trade.sl_atr_mult
+    values: [1.5, 2.0, 2.5]
+  - path: trade.tp_atr_mult
+    values: [3.0, 4.0, 5.0]
+  - path: trade.allocation_pct
+    values: [0.03, 0.05, 0.07]
+
+lookback: 200
+initial_balance: 10000
+

--- a/tests/test_strategy_module_template.py
+++ b/tests/test_strategy_module_template.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from tools.deploy_validate import validate_yaml_text
+
+
+def test_strategy_module_template_is_deploy_validatable():
+    root = Path(__file__).resolve().parents[1]
+    cfg = root / "research" / "strategy_modules" / "template" / "strategy.yaml"
+    errs = validate_yaml_text(cfg.read_text(encoding="utf-8"))
+    assert errs == []
+


### PR DESCRIPTION
Fixes #62.

Adds a strategy-module template directory (config + sweep spec + docs) that plugs into the existing factory workflow, plus a small test ensuring the template config passes deployment-time validation.