### PR TITLE
bt-gpu: Fix sweep kernel parity for sub-bars

### DIFF
--- a/backtester/crates/bt-gpu/Cargo.toml
+++ b/backtester/crates/bt-gpu/Cargo.toml
@@ -3,6 +3,11 @@ name = "bt-gpu"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Convenience flag to match workspace CLI feature naming.
+# bt-gpu is inherently GPU-backed and always compiles CUDA kernels in build.rs.
+gpu = []
+
 [dependencies]
 bt-core = { path = "../bt-core" }
 bt-data = { path = "../bt-data" }

--- a/backtester/crates/bt-gpu/shaders/sweep_engine.wgsl
+++ b/backtester/crates/bt-gpu/shaders/sweep_engine.wgsl
@@ -99,7 +99,7 @@ struct GpuComboConfig {
     add_cooldown_minutes: u32, add_min_profit_atr: f32, add_min_confidence: u32,
     entry_min_confidence: u32, _p4: u32,
     enable_partial_tp: u32, tp_partial_pct: f32, tp_partial_min_notional_usd: f32,
-    trailing_start_atr: f32, trailing_distance_atr: f32, _p5: u32,
+    trailing_start_atr: f32, trailing_distance_atr: f32, tp_partial_atr_mult: f32,
     enable_ssf_filter: u32, enable_breakeven_stop: u32, breakeven_start_atr: f32,
     breakeven_buffer_atr: f32,
     trailing_start_atr_low_conf: f32, trailing_distance_atr_low_conf: f32,

--- a/backtester/crates/bt-gpu/src/buffers.rs
+++ b/backtester/crates/bt-gpu/src/buffers.rs
@@ -254,7 +254,7 @@ pub struct GpuComboConfig {
     pub tp_partial_min_notional_usd: f32,
     pub trailing_start_atr: f32,
     pub trailing_distance_atr: f32,
-    pub _pad5: u32,
+    pub tp_partial_atr_mult: f32,
 
     // SSF + breakeven [46-49]
     pub enable_ssf_filter: u32,
@@ -553,7 +553,7 @@ impl GpuComboConfig {
             tp_partial_min_notional_usd: tc.tp_partial_min_notional_usd as f32,
             trailing_start_atr: tc.trailing_start_atr as f32,
             trailing_distance_atr: tc.trailing_distance_atr as f32,
-            _pad5: 0,
+            tp_partial_atr_mult: tc.tp_partial_atr_mult as f32,
 
             enable_ssf_filter: tc.enable_ssf_filter as u32,
             enable_breakeven_stop: tc.enable_breakeven_stop as u32,


### PR DESCRIPTION
Fixes CUDA sweep kernel parity against CPU sub-bar semantics.

Changes:
- Do not override hybrid volume with sub-bar candle volume.
- Implement tp_partial_atr_mult partial TP ladder (separate partial vs full TP levels).
- Continue sub-bar evaluation after partial TP (do not break the sub-bar loop).
- Align glitch guard with CPU: honour block_exits_on_extreme_dev, check both price deviation pct and ATR deviation, and still update trailing when exits are blocked.
- Add a no-op bt-gpu 'gpu' feature so 'cargo test -p bt-gpu --features gpu' works as intended.

Tests:
- cd backtester && cargo test -p bt-gpu --features gpu