### PR TITLE
chore: fix ruff check failures

### DIFF
--- a/analysis/post_trade/post_trade_analytics.ipynb
+++ b/analysis/post_trade/post_trade_analytics.ipynb
@@ -4,13 +4,13 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# Post-Trade Analytics (AQC-905)\\n",
-        "\\n",
-        "This notebook is a lightweight companion to `tools/post_trade_analytics.py`.\\n",
-        "\\n",
-        "Inputs:\\n",
-        "- A trade CSV (from `mei-backtester replay --export-trades`).\\n",
-        "- An events JSONL (from `artifacts/events/events.jsonl`).\\n"
+        "# Post-Trade Analytics (AQC-905)\n",
+        "\n",
+        "This notebook is a lightweight companion to `tools/post_trade_analytics.py`.\n",
+        "\n",
+        "Inputs:\n",
+        "- A trade CSV (from `mei-backtester replay --export-trades`).\n",
+        "- An events JSONL (from `artifacts/events/events.jsonl`).\n"
       ]
     },
     {
@@ -19,15 +19,15 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from pathlib import Path\\n",
-        "import pandas as pd\\n",
-        "import json\\n",
-        "\\n",
-        "TRADES_CSV = Path(\"/tmp/trades.csv\")\\n",
-        "EVENTS_JSONL = Path(\"artifacts/events/events.jsonl\")\\n",
-        "\\n",
-        "trades = pd.read_csv(TRADES_CSV)\\n",
-        "trades.head()\\n"
+        "from pathlib import Path\n",
+        "import pandas as pd\n",
+        "import json\n",
+        "\n",
+        "TRADES_CSV = Path(\"/tmp/trades.csv\")\n",
+        "EVENTS_JSONL = Path(\"artifacts/events/events.jsonl\")\n",
+        "\n",
+        "trades = pd.read_csv(TRADES_CSV)\n",
+        "trades.head()\n"
       ]
     },
     {
@@ -36,10 +36,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Symbol contribution\\n",
-        "trades[\"pnl_net_usd\"] = trades[\"pnl_usd\"].fillna(0.0) - trades[\"fee_usd\"].fillna(0.0)\\n",
-        "by_symbol = trades.groupby(\"symbol\").agg(trades=(\"trade_id\",\"count\"), pnl_net_usd=(\"pnl_net_usd\",\"sum\")).sort_values(\"pnl_net_usd\", ascending=False)\\n",
-        "by_symbol.head(20)\\n"
+        "# Symbol contribution\n",
+        "trades[\"pnl_net_usd\"] = trades[\"pnl_usd\"].fillna(0.0) - trades[\"fee_usd\"].fillna(0.0)\n",
+        "by_symbol = trades.groupby(\"symbol\").agg(trades=(\"trade_id\",\"count\"), pnl_net_usd=(\"pnl_net_usd\",\"sum\")).sort_values(\"pnl_net_usd\", ascending=False)\n",
+        "by_symbol.head(20)\n"
       ]
     },
     {
@@ -48,34 +48,34 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Entry audit events (ENTRY_*)\\n",
-        "events = []\\n",
-        "if EVENTS_JSONL.exists():\\n",
-        "    for ln in EVENTS_JSONL.read_text(encoding=\"utf-8\", errors=\"replace\").splitlines():\\n",
-        "        s = ln.strip()\\n",
-        "        if not s:\\n",
-        "            continue\\n",
-        "        try:\\n",
-        "            obj = json.loads(s)\\n",
-        "        except Exception:\\n",
-        "            continue\\n",
-        "        if isinstance(obj, dict):\\n",
-        "            events.append(obj)\\n",
-        "\\n",
-        "entry = []\\n",
-        "for e in events:\\n",
-        "    if str(e.get(\"schema\")) != \"aiq_event_v1\":\\n",
-        "        continue\\n",
-        "    if str(e.get(\"kind\", \"\")).lower() != \"audit\":\\n",
-        "        continue\\n",
-        "    data = e.get(\"data\") if isinstance(e.get(\"data\"), dict) else {}\\n",
-        "    ev = str(data.get(\"event\", \"\"))\\n",
-        "    if not ev.startswith(\"ENTRY_\"):\\n",
-        "        continue\\n",
-        "    entry.append({\"ts\": e.get(\"ts\"), \"symbol\": e.get(\"symbol\"), \"event\": ev})\\n",
-        "\\n",
-        "entry_df = pd.DataFrame(entry)\\n",
-        "entry_df.groupby(\"event\").size().sort_values(ascending=False).head(30)\\n"
+        "# Entry audit events (ENTRY_*)\n",
+        "events = []\n",
+        "if EVENTS_JSONL.exists():\n",
+        "    for ln in EVENTS_JSONL.read_text(encoding=\"utf-8\", errors=\"replace\").splitlines():\n",
+        "        s = ln.strip()\n",
+        "        if not s:\n",
+        "            continue\n",
+        "        try:\n",
+        "            obj = json.loads(s)\n",
+        "        except Exception:\n",
+        "            continue\n",
+        "        if isinstance(obj, dict):\n",
+        "            events.append(obj)\n",
+        "\n",
+        "entry = []\n",
+        "for e in events:\n",
+        "    if str(e.get(\"schema\")) != \"aiq_event_v1\":\n",
+        "        continue\n",
+        "    if str(e.get(\"kind\", \"\")).lower() != \"audit\":\n",
+        "        continue\n",
+        "    data = e.get(\"data\") if isinstance(e.get(\"data\"), dict) else {}\n",
+        "    ev = str(data.get(\"event\", \"\"))\n",
+        "    if not ev.startswith(\"ENTRY_\"):\n",
+        "        continue\n",
+        "    entry.append({\"ts\": e.get(\"ts\"), \"symbol\": e.get(\"symbol\"), \"event\": ev})\n",
+        "\n",
+        "entry_df = pd.DataFrame(entry)\n",
+        "entry_df.groupby(\"event\").size().sort_values(ascending=False).head(30)\n"
       ]
     }
   ],
@@ -93,4 +93,3 @@
   "nbformat": 4,
   "nbformat_minor": 5
 }
-

--- a/factory_run.py
+++ b/factory_run.py
@@ -916,7 +916,7 @@ def _reproduce_run(*, artifacts_root: Path, source_run_id: str) -> int:
     _write_json(run_dir / "reports" / "report.json", {"items": replay_reports})
 
     validation_md = _render_validation_report_md(
-        replay_reports, score_min_trades=int(getattr(args, "score_min_trades", 30) or 30)
+        replay_reports, score_min_trades=int(source_args.get("score_min_trades", 30) or 30)
     )
     (run_dir / "reports" / "validation_report.md").write_text(validation_md, encoding="utf-8")
 

--- a/tests/test_factory_smoke_run_integration.py
+++ b/tests/test_factory_smoke_run_integration.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import stat
 import time

--- a/tests/test_interval_orchestrator.py
+++ b/tests/test_interval_orchestrator.py
@@ -1,7 +1,5 @@
 from types import SimpleNamespace
 
-import pytest
-
 from tools.interval_orchestrator import orchestrate_interval_restart
 
 
@@ -84,4 +82,3 @@ def test_orchestrate_restart_leaves_pause_file_on_is_active_failure(tmp_path, mo
 
     assert any(not r.ok for r in res)
     assert pause_file.exists()
-

--- a/tools/interval_orchestrator.py
+++ b/tools/interval_orchestrator.py
@@ -12,7 +12,6 @@ This module provides an orchestrated restart flow that:
 from __future__ import annotations
 
 import argparse
-import os
 import subprocess
 import time
 from dataclasses import dataclass
@@ -154,4 +153,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tools/walk_forward_validate.py
+++ b/tools/walk_forward_validate.py
@@ -22,7 +22,6 @@ import os
 import sqlite3
 import statistics
 import subprocess
-import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone


### PR DESCRIPTION
## Summary

- Fix Ruff parsing for `analysis/post_trade/post_trade_analytics.ipynb` by normalising cell source newlines.
- Fix undefined name in `factory_run.py` reproduce flow (use `source_args` for `score_min_trades`).
- Remove a few unused imports flagged by Ruff.

## Testing

- `uv run ruff check .`
- `uv run pytest`
