### PR TITLE
ops: fix v8 systemd template env expansion

### DIFF
--- a/docs/v8_parallel_instance.md
+++ b/docs/v8_parallel_instance.md
@@ -64,7 +64,7 @@ Then edit:
 
 - `~/.config/openclaw/ai-quant-universe-v8.env` (symbols / intervals)
 - `~/.config/openclaw/ai-quant-v8.env` (Discord channel, kill-switch file, retention)
-- `~/.config/openclaw/ai-quant-monitor-v8.env` (port + v8 WS socket)
+- `~/.config/openclaw/ai-quant-monitor-v8.env` (bind + port)
 
 ## 4) Install v8 systemd User Units
 
@@ -113,4 +113,3 @@ Artifacts:
 - `artifacts/YYYY-MM-DD/run_<run_id>/`
 - `artifacts/registry/registry.sqlite`
 - `artifacts/deployments/paper/.../deploy_event.json`
-

--- a/systemd/ai-quant-monitor-v8.env.example
+++ b/systemd/ai-quant-monitor-v8.env.example
@@ -5,10 +5,8 @@
 AIQ_MONITOR_BIND=127.0.0.1
 AIQ_MONITOR_PORT=61018
 
-# Point the monitor at the v8 WS sidecar socket (must match your v8 sidecar unit).
-AI_QUANT_WS_SIDECAR_SOCK=$XDG_RUNTIME_DIR/openclaw-ai-quant-ws-v8.sock
+# The WS sidecar socket is set in the v8 monitor systemd unit via `%t`.
 
 # Optional overrides:
 # AIQ_MONITOR_PAPER_DB=trading_engine.db
 # AIQ_MONITOR_LIVE_DB=trading_engine_live.db
-

--- a/systemd/openclaw-ai-quant-factory-v8.service.example
+++ b/systemd/openclaw-ai-quant-factory-v8.service.example
@@ -14,11 +14,11 @@ EnvironmentFile=-%h/.config/openclaw/ai-quant-v8.env
 Environment=MEI_BACKTESTER_BIN=$PROJECT_DIR/backtester/dist/mei-backtester-gpu
 
 # WSL2 CUDA: ensure libcuda can be found by cudarc.
-Environment=LD_LIBRARY_PATH=/usr/lib/wsl/lib:$LD_LIBRARY_PATH
+# On native Linux, you can usually remove this line.
+Environment=LD_LIBRARY_PATH=/usr/lib/wsl/lib
 
 # Prevent overlapping runs.
 ExecStart=/usr/bin/flock -n %t/openclaw-ai-quant-factory-v8.lock /usr/bin/env bash -lc "cd \"$PROJECT_DIR\" && \"$PROJECT_DIR/.venv/bin/python3\" -u tools/factory_cycle.py --profile daily --strategy-mode primary --gpu --tpe --walk-forward --slippage-stress --concentration-checks --sensitivity-checks --service openclaw-ai-quant-trader-v8 --ws-service openclaw-ai-quant-ws-sidecar-v8 --discord-target 1470924841858236446"
 
 [Install]
 WantedBy=default.target
-

--- a/systemd/openclaw-ai-quant-monitor-v8.service.example
+++ b/systemd/openclaw-ai-quant-monitor-v8.service.example
@@ -7,6 +7,7 @@ Wants=network-online.target openclaw-ai-quant-ws-sidecar-v8.service
 Type=simple
 WorkingDirectory=$PROJECT_DIR
 EnvironmentFile=-%h/.config/openclaw/ai-quant-monitor-v8.env
+Environment=AI_QUANT_WS_SIDECAR_SOCK=%t/openclaw-ai-quant-ws-v8.sock
 ExecStart=$PROJECT_DIR/.venv/bin/python3 -u monitor/server.py
 Restart=always
 RestartSec=5
@@ -14,4 +15,3 @@ KillMode=process
 
 [Install]
 WantedBy=default.target
-

--- a/systemd/openclaw-ai-quant-ws-sidecar-v8.service.example
+++ b/systemd/openclaw-ai-quant-ws-sidecar-v8.service.example
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=simple
 WorkingDirectory=$PROJECT_DIR
 EnvironmentFile=-%h/.config/openclaw/ai-quant-universe-v8.env
-ExecStart=$HOME/.local/bin/openclaw-ai-quant-ws-sidecar-v8
+ExecStart=%h/.local/bin/openclaw-ai-quant-ws-sidecar-v8
 Restart=always
 RestartSec=5
 KillMode=process
@@ -49,4 +49,3 @@ Environment=RUST_BACKTRACE=1
 
 [Install]
 WantedBy=default.target
-


### PR DESCRIPTION
## Summary

Fixes a couple of systemd-template issues in the v8 parallel instance setup:

- Use `%h` (systemd specifier) instead of `$HOME` in `ExecStart` for the v8 sidecar unit.
- Do not rely on `$XDG_RUNTIME_DIR` expansion in EnvironmentFile; set `AI_QUANT_WS_SIDECAR_SOCK` in the unit via `%t`.
- Make `LD_LIBRARY_PATH` example safe for systemd by avoiding `$LD_LIBRARY_PATH` expansion.

## Testing

- `uv run ruff check .`
- `uv run pytest`
