### PR TITLE
AQC-401: fix factory_run path handling for backtester cwd

### DIFF
--- a/tests/test_factory_run_path_resolution.py
+++ b/tests/test_factory_run_path_resolution.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import factory_run
+
+
+def test_resolve_path_for_backtester_resolves_repo_root_relative_paths() -> None:
+    p = factory_run._resolve_path_for_backtester("config/strategy_overrides.yaml")
+    assert p is not None
+    pp = Path(p)
+    assert pp.is_absolute()
+    assert pp.exists()
+    assert pp.name == "strategy_overrides.yaml"
+
+
+def test_resolve_path_for_backtester_resolves_backtester_relative_sweep_specs() -> None:
+    p = factory_run._resolve_path_for_backtester("sweeps/smoke.yaml")
+    assert p is not None
+    pp = Path(p)
+    assert pp.is_absolute()
+    assert pp.exists()
+    assert pp.name == "smoke.yaml"
+


### PR DESCRIPTION
Context\n- v8 factory systemd run executes the Rust backtester with cwd=backtester/. Repo-relative paths (e.g. backtester/sweeps/*.yaml, config/*.yaml, candles_dbs/*) can break and cause sweep failures.\n\nChanges\n- Resolve common CLI paths to absolute paths before invoking the backtester (config, sweep spec, candles DB, funding DB, walk-forward splits JSON).\n- Auto-detect nvidia-smi on WSL2 (fallback to /usr/lib/wsl/lib/nvidia-smi when not on PATH).\n- Add unit tests for path resolution.