### PR TITLE
fix(factory_run): expand candles-db dirs into candle-only DB files

### DIFF
--- a/tests/test_factory_run_path_resolution.py
+++ b/tests/test_factory_run_path_resolution.py
@@ -23,10 +23,17 @@ def test_resolve_path_for_backtester_resolves_backtester_relative_sweep_specs() 
     assert pp.name == "smoke.yaml"
 
 
-def test_normalise_candles_db_dir_for_backtester_uses_candles_glob(tmp_path) -> None:
-    (tmp_path / "candles_1m.db").write_text("", encoding="utf-8")
-    (tmp_path / "funding_rates.db").write_text("", encoding="utf-8")
+def test_normalise_candles_db_dir_for_backtester_expands_to_candle_db_files(tmp_path) -> None:
+    c1 = tmp_path / "candles_1m.db"
+    c2 = tmp_path / "candles_5m.db"
+    funding = tmp_path / "funding_rates.db"
+    c1.write_text("", encoding="utf-8")
+    c2.write_text("", encoding="utf-8")
+    funding.write_text("", encoding="utf-8")
 
     out = factory_run._normalise_candles_db_arg_for_backtester(str(tmp_path))
     assert out is not None
-    assert out.endswith("candles_*.db")
+    parts = out.split(",")
+    assert str(c1.resolve()) in parts
+    assert str(c2.resolve()) in parts
+    assert str(funding.resolve()) not in parts


### PR DESCRIPTION
Context\n- The Rust backtester expands directories but does not support glob patterns. Converting a candles DB dir to candles_*.db causes failures (unable to open database file).\n- Passing the dir directly can include funding_rates.db and fail with "no such table: candles".\n\nChanges\n- Expand directory inputs into an explicit comma-separated list of candles_*.db files.\n- Update unit test to assert funding_rates.db is excluded.