### PR TITLE
fix(factory): pass exit/entry candle DBs to backtester

### DIFF
--- a/factory_run.py
+++ b/factory_run.py
@@ -995,7 +995,14 @@ def _reproduce_run(*, artifacts_root: Path, source_run_id: str) -> int:
             str(out_json),
         ]
         if candles_db_bt:
-            replay_argv += ["--candles-db", str(candles_db_bt)]
+            replay_argv += [
+                "--candles-db",
+                str(candles_db_bt),
+                "--exit-candles-db",
+                str(candles_db_bt),
+                "--entry-candles-db",
+                str(candles_db_bt),
+            ]
         if funding_db_bt:
             replay_argv += ["--funding-db", str(funding_db_bt)]
 
@@ -1287,7 +1294,14 @@ def main(argv: list[str] | None = None) -> int:
             str(int(args.top_n)),
         ]
         if bt_candles_db:
-            sweep_argv += ["--candles-db", str(bt_candles_db)]
+            sweep_argv += [
+                "--candles-db",
+                str(bt_candles_db),
+                "--exit-candles-db",
+                str(bt_candles_db),
+                "--entry-candles-db",
+                str(bt_candles_db),
+            ]
         if bt_funding_db:
             sweep_argv += ["--funding-db", str(bt_funding_db)]
         if bool(args.gpu):
@@ -1523,7 +1537,14 @@ def main(argv: list[str] | None = None) -> int:
             str(out_json),
         ]
         if bt_candles_db:
-            replay_argv += ["--candles-db", str(bt_candles_db)]
+            replay_argv += [
+                "--candles-db",
+                str(bt_candles_db),
+                "--exit-candles-db",
+                str(bt_candles_db),
+                "--entry-candles-db",
+                str(bt_candles_db),
+            ]
         if bt_funding_db:
             replay_argv += ["--funding-db", str(bt_funding_db)]
         if trades_csv is not None:

--- a/tools/sensitivity_check.py
+++ b/tools/sensitivity_check.py
@@ -366,7 +366,14 @@ def main(argv: list[str] | None = None) -> int:
             str(v_json),
         ]
         if args.candles_db:
-            replay_argv += ["--candles-db", str(args.candles_db)]
+            replay_argv += [
+                "--candles-db",
+                str(args.candles_db),
+                "--exit-candles-db",
+                str(args.candles_db),
+                "--entry-candles-db",
+                str(args.candles_db),
+            ]
         if args.funding_db:
             replay_argv += ["--funding-db", str(args.funding_db)]
 

--- a/tools/slippage_stress.py
+++ b/tools/slippage_stress.py
@@ -150,7 +150,14 @@ def main(argv: list[str] | None = None) -> int:
             str(replay_out),
         ]
         if args.candles_db:
-            replay_argv += ["--candles-db", str(args.candles_db)]
+            replay_argv += [
+                "--candles-db",
+                str(args.candles_db),
+                "--exit-candles-db",
+                str(args.candles_db),
+                "--entry-candles-db",
+                str(args.candles_db),
+            ]
         if args.funding_db:
             replay_argv += ["--funding-db", str(args.funding_db)]
 

--- a/tools/walk_forward_validate.py
+++ b/tools/walk_forward_validate.py
@@ -387,7 +387,14 @@ def main(argv: list[str] | None = None) -> int:
             str(replay_out),
         ]
         if args.candles_db:
-            replay_argv += ["--candles-db", str(args.candles_db)]
+            replay_argv += [
+                "--candles-db",
+                str(args.candles_db),
+                "--exit-candles-db",
+                str(args.candles_db),
+                "--entry-candles-db",
+                str(args.candles_db),
+            ]
         if args.funding_db:
             replay_argv += ["--funding-db", str(args.funding_db)]
 


### PR DESCRIPTION
Context\n- Backtester auto-resolves exit/entry candle DBs to candles_dbs/candles_{interval}.db when entry/exit intervals are enabled in YAML.\n- When invoked with cwd=backtester/, that relative path breaks for the v8 factory cycle.\n\nChanges\n- When --candles-db is provided, also pass --exit-candles-db and --entry-candles-db (same DB set) for sweep/replay.\n- Propagate the same fix to walk-forward/slippage/sensitivity tools that invoke backtester replay.