### PR TITLE
fix(factory_run): omit --top-n when set to 0

### DIFF
--- a/factory_run.py
+++ b/factory_run.py
@@ -1290,9 +1290,10 @@ def main(argv: list[str] | None = None) -> int:
             str(args.interval),
             "--output",
             str(sweep_out),
-            "--top-n",
-            str(int(args.top_n)),
         ]
+        top_n = int(args.top_n or 0)
+        if top_n > 0:
+            sweep_argv += ["--top-n", str(top_n)]
         if bt_candles_db:
             sweep_argv += [
                 "--candles-db",


### PR DESCRIPTION
Context\n- Backtester uses --top-n to limit JSONL rows written for sweeps (including GPU TPE).\n- factory_run always passed --top-n 0, producing empty sweep_results.jsonl and breaking config generation.\n\nChanges\n- Only pass --top-n when top_n > 0 so sweep_results.jsonl contains results for downstream steps.