### PR TITLE
backtester: Scope CPU sweep by from/to timestamps

### DIFF
--- a/backtester/crates/bt-cli/src/main.rs
+++ b/backtester/crates/bt-cli/src/main.rs
@@ -833,6 +833,8 @@ fn cmd_sweep(args: SweepArgs) -> Result<(), Box<dyn std::error::Error>> {
         exit_candles.as_ref(),
         entry_candles.as_ref(),
         funding_rates.as_ref(),
+        from_ts,
+        to_ts,
     );
     let sweep_elapsed = sweep_start.elapsed();
 

--- a/backtester/crates/bt-core/src/sweep.rs
+++ b/backtester/crates/bt-core/src/sweep.rs
@@ -298,6 +298,9 @@ fn apply_one(cfg: &mut StrategyConfig, path: &str, value: f64) {
 /// Run a parameter sweep: generate all config combinations, run each in parallel.
 ///
 /// Results are sorted by `total_pnl` descending (best first).
+///
+/// `from_ts`/`to_ts` are forwarded to the simulation engine to restrict trading to a
+/// specific time window.
 pub fn run_sweep(
     base_cfg: &StrategyConfig,
     spec: &SweepSpec,
@@ -305,6 +308,8 @@ pub fn run_sweep(
     exit_candles: Option<&CandleData>,
     entry_candles: Option<&CandleData>,
     funding_rates: Option<&FundingRateData>,
+    from_ts: Option<i64>,
+    to_ts: Option<i64>,
 ) -> Vec<SweepResult> {
     let combos = generate_combinations(&spec.axes);
     let total = combos.len();
@@ -336,8 +341,8 @@ pub fn run_sweep(
                 entry_candles_arc.as_deref(),
                 funding_rates_arc.as_deref(),
                 None, // sweeps always start clean (no init-state)
-                None, // from_ts: CPU sweep doesn't scope (GPU sweep does via trade kernel)
-                None, // to_ts
+                from_ts,
+                to_ts,
             );
 
             let rpt = report::build_report(

--- a/backtester/crates/bt-gpu/tests/cpu_gpu_parity_sweep_1h_3m.rs
+++ b/backtester/crates/bt-gpu/tests/cpu_gpu_parity_sweep_1h_3m.rs
@@ -98,7 +98,16 @@ fn cpu_gpu_parity_sweep_1h_3m_tiny_fixture() {
         lookback: 0,
     };
 
-    let cpu = bt_core::sweep::run_sweep(&cfg, &spec, &candles, Some(&exit_candles), None, None);
+    let cpu = bt_core::sweep::run_sweep(
+        &cfg,
+        &spec,
+        &candles,
+        Some(&exit_candles),
+        None,
+        None,
+        None,
+        None,
+    );
     assert_eq!(cpu.len(), 1);
     let cpu_rpt = &cpu[0].report;
     assert_eq!(cpu_rpt.total_trades, 1, "Fixture should produce exactly one trade on CPU");


### PR DESCRIPTION
CPU sweep previously ignored the CLI scope window (from_ts/to_ts), while the GPU path restricts trading via the trade kernel bar range. This made CPU vs GPU sweep results non-comparable when auto-scope is active (apples-to-apples window).\n\nChanges:\n- Thread from_ts/to_ts through bt_core::sweep::run_sweep() into engine::run_simulation().\n- Pass from_ts/to_ts from bt-cli sweep CPU path.\n- Update the CPU/GPU parity sweep test call signature.