### PR TITLE
GPU sweep parity: TP mult + indicator-bar exit check

### DIFF
--- a/backtester/crates/bt-gpu/shaders/sweep_engine.wgsl
+++ b/backtester/crates/bt-gpu/shaders/sweep_engine.wgsl
@@ -770,8 +770,8 @@ fn is_pesc_blocked(state: ptr<function, GpuComboState>, sym: u32, desired_type: 
 // ── Dynamic TP Multiplier ───────────────────────────────────────────────────
 
 fn get_tp_mult(snap: GpuSnapshot, cfg: ptr<function, GpuComboConfig>) -> f32 {
-    if snap.adx > (*cfg).tp_strong_adx_gt { return 7.0; }
-    if snap.adx < (*cfg).tp_weak_adx_lt { return 3.0; }
+    // Parity with CPU: always use the configured TP ATR multiplier.
+    // Dynamic TP scaling based on ADX is intentionally disabled on GPU.
     return (*cfg).tp_atr_mult;
 }
 


### PR DESCRIPTION
Summary:\n- Disable ADX-based dynamic TP scaling on GPU (match CPU: always use cfg.tp_atr_mult).\n- Sub-bar path: evaluate exits once on the indicator-bar snapshot before scanning sub-bars, matching CPU semantics.\n\nTests:\n- cargo test (backtester workspace)\n- cargo test -p bt-gpu --test cpu_gpu_parity_sweep_1h_3m -- --ignored