### PR TITLE
feat(backtester): add full 144v sweep profile

### DIFF
--- a/backtester/crates/bt-core/src/sweep.rs
+++ b/backtester/crates/bt-core/src/sweep.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use serde::Deserialize;
 
 use crate::candle::{CandleData, FundingRateData};
-use crate::config::{Confidence, StrategyConfig};
+use crate::config::{Confidence, MacdMode, StrategyConfig};
 use crate::engine;
 use crate::report::{self, SimReport};
 
@@ -113,6 +113,7 @@ fn apply_one(cfg: &mut StrategyConfig, path: &str, value: f64) {
         "trade.min_atr_pct" => cfg.trade.min_atr_pct = value,
         "trade.slippage_bps" => cfg.trade.slippage_bps = value,
         "trade.min_notional_usd" => cfg.trade.min_notional_usd = value,
+        "trade.use_bbo_for_fills" => cfg.trade.use_bbo_for_fills = value != 0.0,
         "trade.bump_to_min_notional" => cfg.trade.bump_to_min_notional = value != 0.0,
         "trade.max_total_margin_pct" => cfg.trade.max_total_margin_pct = value,
         "trade.reentry_cooldown_minutes" => cfg.trade.reentry_cooldown_minutes = value as usize,
@@ -134,6 +135,7 @@ fn apply_one(cfg: &mut StrategyConfig, path: &str, value: f64) {
         "trade.rsi_exit_lb_lo_profit_low_conf" => cfg.trade.rsi_exit_lb_lo_profit_low_conf = value,
         "trade.rsi_exit_lb_hi_profit_low_conf" => cfg.trade.rsi_exit_lb_hi_profit_low_conf = value,
         "trade.tp_partial_pct" => cfg.trade.tp_partial_pct = value,
+        "trade.tp_partial_min_notional_usd" => cfg.trade.tp_partial_min_notional_usd = value,
         "trade.add_min_profit_atr" => cfg.trade.add_min_profit_atr = value,
         "trade.add_fraction_of_base_margin" => cfg.trade.add_fraction_of_base_margin = value,
         "trade.max_adds_per_symbol" => cfg.trade.max_adds_per_symbol = value as usize,
@@ -201,6 +203,13 @@ fn apply_one(cfg: &mut StrategyConfig, path: &str, value: f64) {
         "thresholds.entry.slow_drift_min_adx" => cfg.thresholds.entry.slow_drift_min_adx = value,
         "thresholds.entry.slow_drift_rsi_long_min" => cfg.thresholds.entry.slow_drift_rsi_long_min = value,
         "thresholds.entry.slow_drift_rsi_short_max" => cfg.thresholds.entry.slow_drift_rsi_short_max = value,
+        "thresholds.entry.macd_hist_entry_mode" => {
+            cfg.thresholds.entry.macd_hist_entry_mode = match value as u8 {
+                0 => MacdMode::Accel,
+                1 => MacdMode::Sign,
+                _ => MacdMode::None,
+            };
+        }
 
         // === Thresholds — ranging ===
         "thresholds.ranging.min_signals" => cfg.thresholds.ranging.min_signals = value as usize,

--- a/backtester/sweeps/full_144v.yaml
+++ b/backtester/sweeps/full_144v.yaml
@@ -1,0 +1,799 @@
+# sweep_full 144v profile
+#
+# Scope:
+# - Expands sweep coverage from the legacy 34-axis profile to broad strategy coverage.
+# - Includes every backtester-sweepable strategy leaf in config scope (engine/runtime/ops/universe/risk excluded).
+# - Keeps legacy 34-axis ranges where defined; new axes use baseline-centred ranges.
+#
+# Enum encoding:
+# - trade.entry_min_confidence: 0=low, 1=medium, 2=high
+# - trade.add_min_confidence: 0=low, 1=medium, 2=high
+# - thresholds.entry.pullback_confidence: 0=low, 1=medium, 2=high
+# - thresholds.entry.macd_hist_entry_mode: 0=accel, 1=sign, 2=none
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: filters.adx_rising_saturation
+  values:
+  - 28.0
+  - 40.0
+  - 52.0
+- path: filters.enable_anomaly_filter
+  values:
+  - 0.0
+  - 1.0
+- path: filters.enable_extension_filter
+  values:
+  - 0.0
+  - 1.0
+- path: filters.enable_ranging_filter
+  values:
+  - 0.0
+  - 1.0
+- path: filters.require_adx_rising
+  values:
+  - 0.0
+  - 1.0
+- path: filters.require_btc_alignment
+  values:
+  - 0.0
+  - 1.0
+- path: filters.require_macro_alignment
+  values:
+  - 0.0
+  - 1.0
+- path: filters.require_volume_confirmation
+  values:
+  - 0.0
+  - 1.0
+- path: filters.use_stoch_rsi_filter
+  values:
+  - 0.0
+  - 1.0
+- path: filters.vol_confirm_include_prev
+  values:
+  - 0.0
+  - 1.0
+- path: indicators.adx_window
+  values:
+  - 8.0
+  - 10.0
+  - 12.0
+  - 14.0
+  - 16.0
+  - 18.0
+- path: indicators.atr_window
+  values:
+  - 10.0
+  - 12.0
+  - 14.0
+  - 16.0
+  - 18.0
+  - 20.0
+- path: indicators.ave_avg_atr_window
+  values:
+  - 35.0
+  - 50.0
+  - 65.0
+- path: indicators.bb_width_avg_window
+  values:
+  - 15.0
+  - 20.0
+  - 25.0
+  - 30.0
+  - 35.0
+  - 40.0
+  - 45.0
+  - 50.0
+- path: indicators.bb_window
+  values:
+  - 10.0
+  - 15.0
+  - 20.0
+  - 25.0
+  - 30.0
+- path: indicators.ema_fast_window
+  values:
+  - 5.0
+  - 6.0
+  - 7.0
+  - 8.0
+  - 9.0
+  - 10.0
+  - 12.0
+  - 14.0
+  - 16.0
+  - 18.0
+  - 20.0
+- path: indicators.ema_macro_window
+  values:
+  - 140.0
+  - 200.0
+  - 260.0
+- path: indicators.ema_slow_window
+  values:
+  - 10.0
+  - 15.0
+  - 20.0
+  - 25.0
+  - 30.0
+  - 35.0
+  - 40.0
+  - 45.0
+  - 50.0
+- path: indicators.rsi_window
+  values:
+  - 10.0
+  - 12.0
+  - 14.0
+  - 16.0
+  - 18.0
+  - 20.0
+- path: indicators.stoch_rsi_smooth1
+  values:
+  - 2.0
+  - 3.0
+  - 4.0
+  - 5.0
+- path: indicators.stoch_rsi_smooth2
+  values:
+  - 2.0
+  - 3.0
+  - 4.0
+  - 5.0
+- path: indicators.stoch_rsi_window
+  values:
+  - 10.0
+  - 12.0
+  - 14.0
+  - 16.0
+  - 18.0
+  - 20.0
+- path: indicators.vol_sma_window
+  values:
+  - 10.0
+  - 15.0
+  - 20.0
+  - 25.0
+  - 30.0
+- path: indicators.vol_trend_window
+  values:
+  - 3.0
+  - 4.0
+  - 5.0
+  - 6.0
+  - 7.0
+  - 8.0
+  - 9.0
+  - 10.0
+- path: market_regime.auto_reverse_breadth_high
+  values:
+  - 63.0
+  - 90.0
+  - 100.0
+- path: market_regime.auto_reverse_breadth_low
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: market_regime.breadth_block_long_below
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: market_regime.breadth_block_short_above
+  values:
+  - 63.0
+  - 90.0
+  - 100.0
+- path: market_regime.enable_auto_reverse
+  values:
+  - 0.0
+  - 1.0
+- path: market_regime.enable_regime_filter
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.anomaly.ema_fast_dev_pct_gt
+  values:
+  - 0.35
+  - 0.5
+  - 0.65
+- path: thresholds.anomaly.price_change_pct_gt
+  values:
+  - 0.07
+  - 0.1
+  - 0.13
+- path: thresholds.entry.ave_adx_mult
+  values:
+  - 0.875
+  - 1.25
+  - 1.625
+- path: thresholds.entry.ave_atr_ratio_gt
+  values:
+  - 1.05
+  - 1.5
+  - 1.95
+- path: thresholds.entry.ave_avg_atr_window
+  values:
+  - 30.0
+  - 40.0
+  - 50.0
+  - 60.0
+  - 70.0
+  - 80.0
+- path: thresholds.entry.ave_enabled
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.btc_adx_override
+  values:
+  - 28.0
+  - 40.0
+  - 52.0
+- path: thresholds.entry.enable_pullback_entries
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.enable_slow_drift_entries
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.high_conf_volume_mult
+  values:
+  - 1.75
+  - 2.5
+  - 3.25
+- path: thresholds.entry.macd_hist_entry_mode
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+- path: thresholds.entry.max_dist_ema_fast
+  values:
+  - 0.02
+  - 0.03
+  - 0.04
+  - 0.05
+- path: thresholds.entry.min_adx
+  values:
+  - 10.0
+  - 15.0
+  - 20.0
+  - 25.0
+- path: thresholds.entry.pullback_confidence
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+- path: thresholds.entry.pullback_min_adx
+  values:
+  - 15.4
+  - 22.0
+  - 28.6
+- path: thresholds.entry.pullback_require_macd_sign
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.pullback_rsi_long_min
+  values:
+  - 35.0
+  - 50.0
+  - 65.0
+- path: thresholds.entry.pullback_rsi_short_max
+  values:
+  - 35.0
+  - 50.0
+  - 65.0
+- path: thresholds.entry.slow_drift_min_adx
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: thresholds.entry.slow_drift_min_slope_pct
+  values:
+  - 0.00042
+  - 0.0006
+  - 0.00078
+- path: thresholds.entry.slow_drift_require_macd_sign
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.slow_drift_rsi_long_min
+  values:
+  - 35.0
+  - 50.0
+  - 65.0
+- path: thresholds.entry.slow_drift_rsi_short_max
+  values:
+  - 35.0
+  - 50.0
+  - 65.0
+- path: thresholds.entry.slow_drift_slope_window
+  values:
+  - 10.0
+  - 15.0
+  - 20.0
+  - 25.0
+  - 30.0
+  - 35.0
+  - 40.0
+- path: thresholds.ranging.adx_below
+  values:
+  - 14.7
+  - 21.0
+  - 27.3
+- path: thresholds.ranging.bb_width_ratio_below
+  values:
+  - 0.56
+  - 0.8
+  - 1.04
+- path: thresholds.ranging.min_signals
+  values:
+  - 1.0
+  - 2.0
+  - 3.0
+- path: thresholds.ranging.rsi_high
+  values:
+  - 37.1
+  - 53.0
+  - 68.9
+- path: thresholds.ranging.rsi_low
+  values:
+  - 32.9
+  - 47.0
+  - 61.1
+- path: thresholds.stoch_rsi.block_long_if_k_gt
+  values:
+  - 0.595
+  - 0.85
+  - 1.105
+- path: thresholds.stoch_rsi.block_short_if_k_lt
+  values:
+  - 0.105
+  - 0.15
+  - 0.195
+- path: thresholds.tp_and_momentum.adx_strong_gt
+  values:
+  - 28.0
+  - 40.0
+  - 52.0
+- path: thresholds.tp_and_momentum.adx_weak_lt
+  values:
+  - 21.0
+  - 30.0
+  - 39.0
+- path: thresholds.tp_and_momentum.rsi_long_strong
+  values:
+  - 36.4
+  - 52.0
+  - 67.6
+- path: thresholds.tp_and_momentum.rsi_long_weak
+  values:
+  - 39.2
+  - 56.0
+  - 72.8
+- path: thresholds.tp_and_momentum.rsi_short_strong
+  values:
+  - 33.6
+  - 48.0
+  - 62.4
+- path: thresholds.tp_and_momentum.rsi_short_weak
+  values:
+  - 30.8
+  - 44.0
+  - 57.2
+- path: thresholds.tp_and_momentum.tp_mult_strong
+  values:
+  - 4.9
+  - 7.0
+  - 9.1
+- path: thresholds.tp_and_momentum.tp_mult_weak
+  values:
+  - 2.1
+  - 3.0
+  - 3.9
+- path: trade.add_cooldown_minutes
+  values:
+  - 42.0
+  - 60.0
+  - 78.0
+- path: trade.add_fraction_of_base_margin
+  values:
+  - 0.25
+  - 0.5
+  - 0.75
+  - 1.0
+- path: trade.add_min_confidence
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+- path: trade.add_min_profit_atr
+  values:
+  - 0.35
+  - 0.5
+  - 0.65
+- path: trade.adx_sizing_full_adx
+  values:
+  - 28.0
+  - 40.0
+  - 52.0
+- path: trade.adx_sizing_min_mult
+  values:
+  - 0.42
+  - 0.6
+  - 0.78
+- path: trade.allocation_pct
+  values:
+  - 0.05
+  - 0.1
+  - 0.15
+  - 0.2
+  - 0.25
+  - 0.3
+- path: trade.block_exits_on_extreme_dev
+  values:
+  - 0.0
+  - 1.0
+- path: trade.breakeven_buffer_atr
+  values:
+  - 0.035
+  - 0.05
+  - 0.065
+- path: trade.breakeven_start_atr
+  values:
+  - 0.3
+  - 0.4
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - 1.0
+- path: trade.bump_to_min_notional
+  values:
+  - 0.0
+  - 1.0
+- path: trade.confidence_mult_high
+  values:
+  - 0.7
+  - 1.0
+  - 1.3
+- path: trade.confidence_mult_low
+  values:
+  - 0.35
+  - 0.5
+  - 0.65
+- path: trade.confidence_mult_medium
+  values:
+  - 0.3
+  - 0.4
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - 1.0
+- path: trade.enable_breakeven_stop
+  values:
+  - 0.0
+  - 1.0
+- path: trade.enable_dynamic_leverage
+  values:
+  - 0.0
+  - 1.0
+- path: trade.enable_dynamic_sizing
+  values:
+  - 0.0
+  - 1.0
+- path: trade.enable_partial_tp
+  values:
+  - 0.0
+  - 1.0
+- path: trade.enable_pyramiding
+  values:
+  - 0.0
+  - 1.0
+- path: trade.enable_reef_filter
+  values:
+  - 0.0
+  - 1.0
+- path: trade.enable_rsi_overextension_exit
+  values:
+  - 0.0
+  - 1.0
+- path: trade.enable_ssf_filter
+  values:
+  - 0.0
+  - 1.0
+- path: trade.enable_vol_buffered_trailing
+  values:
+  - 0.0
+  - 1.0
+- path: trade.entry_cooldown_s
+  values:
+  - 14.0
+  - 20.0
+  - 26.0
+- path: trade.entry_min_confidence
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+- path: trade.exit_cooldown_s
+  values:
+  - 10.0
+  - 15.0
+  - 20.0
+- path: trade.glitch_atr_mult
+  values:
+  - 8.4
+  - 12.0
+  - 15.6
+- path: trade.glitch_price_dev_pct
+  values:
+  - 0.28
+  - 0.4
+  - 0.52
+- path: trade.leverage
+  values:
+  - 1.0
+  - 2.0
+  - 3.0
+  - 4.0
+  - 5.0
+- path: trade.leverage_high
+  values:
+  - 3.5
+  - 5.0
+  - 6.5
+- path: trade.leverage_low
+  values:
+  - 0.7
+  - 1.0
+  - 1.3
+- path: trade.leverage_max_cap
+  values:
+  - 0.0
+  - 0.5
+  - 1.0
+- path: trade.leverage_medium
+  values:
+  - 2.0
+  - 3.0
+  - 4.0
+  - 5.0
+- path: trade.max_adds_per_symbol
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+  - 3.0
+- path: trade.max_entry_orders_per_loop
+  values:
+  - 4.0
+  - 6.0
+  - 8.0
+- path: trade.max_open_positions
+  values:
+  - 14.0
+  - 20.0
+  - 26.0
+- path: trade.max_total_margin_pct
+  values:
+  - 0.42
+  - 0.6
+  - 0.78
+- path: trade.min_atr_pct
+  values:
+  - 0.0
+  - 0.001
+  - 0.002
+  - 0.003
+  - 0.004
+  - 0.005
+- path: trade.min_notional_usd
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: trade.reef_adx_threshold
+  values:
+  - 31.5
+  - 45.0
+  - 58.5
+- path: trade.reef_long_rsi_block_gt
+  values:
+  - 49.0
+  - 70.0
+  - 91.0
+- path: trade.reef_long_rsi_extreme_gt
+  values:
+  - 52.5
+  - 75.0
+  - 97.5
+- path: trade.reef_short_rsi_block_lt
+  values:
+  - 21.0
+  - 30.0
+  - 39.0
+- path: trade.reef_short_rsi_extreme_lt
+  values:
+  - 17.5
+  - 25.0
+  - 32.5
+- path: trade.reentry_cooldown_max_mins
+  values:
+  - 126.0
+  - 180.0
+  - 234.0
+- path: trade.reentry_cooldown_min_mins
+  values:
+  - 30.0
+  - 45.0
+  - 60.0
+  - 75.0
+  - 90.0
+- path: trade.reentry_cooldown_minutes
+  values:
+  - 42.0
+  - 60.0
+  - 78.0
+- path: trade.reverse_entry_signal
+  values:
+  - 0.0
+  - 1.0
+- path: trade.rsi_exit_lb_hi_profit
+  values:
+  - 21.0
+  - 30.0
+  - 39.0
+- path: trade.rsi_exit_lb_hi_profit_low_conf
+  values:
+  - 0.0
+  - 30.0
+  - 50.0
+- path: trade.rsi_exit_lb_lo_profit
+  values:
+  - 14.0
+  - 20.0
+  - 26.0
+- path: trade.rsi_exit_lb_lo_profit_low_conf
+  values:
+  - 0.0
+  - 30.0
+  - 50.0
+- path: trade.rsi_exit_profit_atr_switch
+  values:
+  - 1.05
+  - 1.5
+  - 1.95
+- path: trade.rsi_exit_ub_hi_profit
+  values:
+  - 49.0
+  - 70.0
+  - 91.0
+- path: trade.rsi_exit_ub_hi_profit_low_conf
+  values:
+  - 0.0
+  - 30.0
+  - 50.0
+- path: trade.rsi_exit_ub_lo_profit
+  values:
+  - 56.0
+  - 80.0
+  - 100.0
+- path: trade.rsi_exit_ub_lo_profit_low_conf
+  values:
+  - 0.0
+  - 30.0
+  - 50.0
+- path: trade.sl_atr_mult
+  values:
+  - 1.0
+  - 1.25
+  - 1.5
+  - 1.75
+  - 2.0
+  - 2.25
+  - 2.5
+  - 2.75
+  - 3.0
+- path: trade.slippage_bps
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: trade.smart_exit_adx_exhaustion_lt
+  values:
+  - 0.0
+  - 15.0
+  - 30.0
+- path: trade.smart_exit_adx_exhaustion_lt_low_conf
+  values:
+  - 0.0
+  - 15.0
+  - 30.0
+- path: trade.tp_atr_mult
+  values:
+  - 3.0
+  - 3.5
+  - 4.0
+  - 4.5
+  - 5.0
+  - 5.5
+  - 6.0
+  - 6.5
+  - 7.0
+  - 7.5
+  - 8.0
+- path: trade.tp_partial_min_notional_usd
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: trade.tp_partial_pct
+  values:
+  - 0.35
+  - 0.5
+  - 0.65
+- path: trade.trailing_distance_atr
+  values:
+  - 0.3
+  - 0.4
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - 1.0
+  - 1.1
+  - 1.2
+- path: trade.trailing_distance_atr_low_conf
+  values:
+  - 0.0
+  - 0.5
+  - 1.0
+- path: trade.trailing_start_atr
+  values:
+  - 0.5
+  - 0.75
+  - 1.0
+  - 1.25
+  - 1.5
+  - 1.75
+  - 2.0
+- path: trade.trailing_start_atr_low_conf
+  values:
+  - 0.0
+  - 0.5
+  - 1.0
+- path: trade.tsme_min_profit_atr
+  values:
+  - 0.7
+  - 1.0
+  - 1.3
+- path: trade.tsme_require_adx_slope_negative
+  values:
+  - 0.0
+  - 1.0
+- path: trade.use_bbo_for_fills
+  values:
+  - 0.0
+  - 1.0
+- path: trade.vol_baseline_pct
+  values:
+  - 0.007
+  - 0.01
+  - 0.013
+- path: trade.vol_scalar_max
+  values:
+  - 0.7
+  - 1.0
+  - 1.3
+- path: trade.vol_scalar_min
+  values:
+  - 0.35
+  - 0.5
+  - 0.65

--- a/backtester/sweeps/run_full_sweep.sh
+++ b/backtester/sweeps/run_full_sweep.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # ═══════════════════════════════════════════════════════════════════════════
-# Full TPE Sweep Runner — 34 axes × 6 main intervals
+# Full TPE Sweep Runner — 144v profile (broad strategy coverage)
 # ═══════════════════════════════════════════════════════════════════════════
 #
-# Runs TPE Bayesian optimization across all 34 parameter axes for each
+# Runs TPE Bayesian optimisation across the default 144v profile for each
 # main candle interval. Auto-scope ensures apple-to-apple within each run.
 #
 # GPU sweep does NOT support sub-bar entry/exit intervals (main only).
@@ -15,9 +15,7 @@
 #   ./run_full_sweep.sh --trials 100000    # quick test
 #   ./run_full_sweep.sh --intervals "15m 1h"  # specific intervals only
 #
-# Expected time (batch=4096, ~114K trials/sec):
-#   500K trials × 6 intervals ≈ 26 seconds total
-#   100K trials × 6 intervals ≈ 6 seconds total
+# Runtime varies by axis count, batch size, and host GPU throughput.
 #
 # Kill if over 10 minutes: built-in timeout per run.
 # ═══════════════════════════════════════════════════════════════════════════
@@ -31,7 +29,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 TRIALS=500000
 BATCH=4096
 SEED=42
-SWEEP_SPEC="sweeps/full_34axis.yaml"
+SWEEP_SPEC="sweeps/full_144v.yaml"
 CONFIG="../config/strategy_overrides.yaml"
 BACKTESTER="./target/release/mei-backtester"
 OUTPUT_DIR="sweep_results"
@@ -47,6 +45,7 @@ while [[ $# -gt 0 ]]; do
         --seed)       SEED="$2"; shift 2 ;;
         --intervals)  INTERVALS="$2"; shift 2 ;;
         --timeout)    TIMEOUT_PER_RUN="$2"; shift 2 ;;
+        --spec)       SWEEP_SPEC="$2"; shift 2 ;;
         --balance)    INITIAL_BALANCE="$2"; shift 2 ;;
         --include-1m) INTERVALS="1m $INTERVALS"; shift ;;
         *)            echo "Unknown arg: $1"; exit 1 ;;
@@ -75,6 +74,16 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:/usr/lib/wsl/lib"
 
 mkdir -p "$OUTPUT_DIR"
 
+AXIS_COUNT="$(python3 - "$SWEEP_SPEC" <<'PY'
+import sys, yaml
+try:
+    spec = yaml.safe_load(open(sys.argv[1], "r", encoding="utf-8").read()) or {}
+    print(len(spec.get("axes", [])))
+except Exception:
+    print("?")
+PY
+)"
+
 # ── Data coverage info ──────────────────────────────────────────────────
 declare -A INTERVAL_DAYS=(
     [1m]="3.5"
@@ -87,7 +96,7 @@ declare -A INTERVAL_DAYS=(
 
 # ── Run ─────────────────────────────────────────────────────────────────
 echo "═══════════════════════════════════════════════════════════════"
-echo "Full TPE Sweep: 34 axes × ${TRIALS} trials × batch=${BATCH}"
+echo "Full TPE Sweep: ${AXIS_COUNT} axes (${SWEEP_SPEC}) × ${TRIALS} trials × batch=${BATCH}"
 echo "Intervals: ${INTERVALS}"
 echo "Timeout per run: ${TIMEOUT_PER_RUN}s"
 echo "═══════════════════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary
- add a new broad-coverage sweep spec at `backtester/sweeps/full_144v.yaml`
- wire `run_full_sweep.sh` to default to the 144v profile and support `--spec` override
- extend Rust sweep override support for:
  - `trade.use_bbo_for_fills`
  - `trade.tp_partial_min_notional_usd`
  - `thresholds.entry.macd_hist_entry_mode`

## Validation
- `cargo check -p bt-core`
- parse `backtester/sweeps/full_144v.yaml` via Python YAML loader
- verify all axes map to recognised `apply_one` paths

## Coverage note
- This profile includes all currently sweepable strategy leaves in scope for Rust backtests.
- Non-sweepable leaves remain: regime gate fields (`market_regime.regime_gate_*`, `enable_regime_gate`) and `watchlist_exclude`.