### PR TITLE
feat(backtester): add 17-phase 144v sweep pack

### DIFF
--- a/backtester/sweeps/full_144v_17phase/README.md
+++ b/backtester/sweeps/full_144v_17phase/README.md
@@ -1,0 +1,31 @@
+# 17-Phase 144v Sweep Pack
+
+This directory contains a phase-based grid sweep pack generated from
+`backtester/sweeps/full_144v.yaml`.
+
+## Why this pack exists
+
+- `full_144v.yaml` gives broad parameter coverage, but the full cartesian grid is intractable.
+- This pack keeps **all 143 axes** while reducing value density per axis for practical grid runs.
+- Total scale stays near the legacy 17-phase workflow.
+
+## Current scale
+
+- Phases: **17**
+- Axes covered: **143** (all `full_144v` axes, each exactly once)
+- Total combos per interval: **17,280**
+
+## Files
+
+- `p01_144v.yaml` ... `p17_144v.yaml`: phase specs
+- `manifest.yaml`: phase metadata, combo counts, and path assignment
+
+## Regeneration
+
+From repo root:
+
+```bash
+python3 backtester/sweeps/generate_17phase_144v.py
+```
+
+This rewrites all phase files and `manifest.yaml` deterministically.

--- a/backtester/sweeps/full_144v_17phase/manifest.yaml
+++ b/backtester/sweeps/full_144v_17phase/manifest.yaml
@@ -1,0 +1,272 @@
+source_spec: backtester/sweeps/full_144v.yaml
+reference_spec: backtester/sweeps/full_34axis.yaml
+phase_count: 17
+total_axes: 143
+total_combo: 17280
+notes:
+- All full_144v axes are included once across the 17 phases.
+- Most axes use 2-point min/max values; selected key axes use 3-point min/mid/max.
+- This keeps runtime near the legacy 17-phase scale while preserving 144v coverage.
+phases:
+- id: p01_144v
+  file: p01_144v.yaml
+  axis_count: 9
+  combo: 1728
+  two_value_axes: 6
+  three_value_axes: 3
+  paths:
+  - indicators.adx_window
+  - market_regime.enable_regime_filter
+  - thresholds.entry.ave_avg_atr_window
+  - thresholds.entry.slow_drift_rsi_long_min
+  - trade.adx_sizing_full_adx
+  - trade.exit_cooldown_s
+  - trade.min_atr_pct
+  - trade.reverse_entry_signal
+  - trade.vol_scalar_min
+- id: p02_144v
+  file: p02_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.atr_window
+  - thresholds.anomaly.ema_fast_dev_pct_gt
+  - thresholds.entry.macd_hist_entry_mode
+  - thresholds.entry.slow_drift_rsi_short_max
+  - trade.adx_sizing_min_mult
+  - trade.glitch_atr_mult
+  - trade.reentry_cooldown_min_mins
+  - trade.rsi_exit_lb_hi_profit_low_conf
+- id: p03_144v
+  file: p03_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.bb_width_avg_window
+  - thresholds.anomaly.price_change_pct_gt
+  - thresholds.entry.max_dist_ema_fast
+  - thresholds.ranging.adx_below
+  - trade.block_exits_on_extreme_dev
+  - trade.glitch_price_dev_pct
+  - trade.rsi_exit_lb_hi_profit
+  - trade.rsi_exit_lb_lo_profit
+- id: p04_144v
+  file: p04_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.bb_window
+  - thresholds.entry.ave_adx_mult
+  - thresholds.entry.min_adx
+  - thresholds.ranging.bb_width_ratio_below
+  - trade.breakeven_buffer_atr
+  - trade.leverage_high
+  - trade.rsi_exit_lb_lo_profit_low_conf
+  - trade.rsi_exit_profit_atr_switch
+- id: p05_144v
+  file: p05_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.ema_fast_window
+  - thresholds.entry.ave_atr_ratio_gt
+  - thresholds.entry.pullback_confidence
+  - thresholds.ranging.min_signals
+  - trade.bump_to_min_notional
+  - trade.leverage_low
+  - trade.rsi_exit_ub_hi_profit
+  - trade.rsi_exit_ub_hi_profit_low_conf
+- id: p06_144v
+  file: p06_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.ema_macro_window
+  - thresholds.entry.ave_enabled
+  - thresholds.entry.slow_drift_slope_window
+  - thresholds.ranging.rsi_high
+  - trade.confidence_mult_high
+  - trade.leverage_max_cap
+  - trade.rsi_exit_ub_lo_profit
+  - trade.sl_atr_mult
+- id: p07_144v
+  file: p07_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.ema_slow_window
+  - thresholds.entry.btc_adx_override
+  - thresholds.ranging.rsi_low
+  - thresholds.tp_and_momentum.tp_mult_strong
+  - trade.confidence_mult_low
+  - trade.max_entry_orders_per_loop
+  - trade.rsi_exit_ub_lo_profit_low_conf
+  - trade.smart_exit_adx_exhaustion_lt
+- id: p08_144v
+  file: p08_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.rsi_window
+  - thresholds.entry.enable_pullback_entries
+  - thresholds.stoch_rsi.block_long_if_k_gt
+  - thresholds.tp_and_momentum.tp_mult_weak
+  - trade.enable_breakeven_stop
+  - trade.max_open_positions
+  - trade.slippage_bps
+  - trade.smart_exit_adx_exhaustion_lt_low_conf
+- id: p09_144v
+  file: p09_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.stoch_rsi_smooth1
+  - thresholds.entry.enable_slow_drift_entries
+  - thresholds.stoch_rsi.block_short_if_k_lt
+  - trade.add_fraction_of_base_margin
+  - trade.enable_dynamic_leverage
+  - trade.max_total_margin_pct
+  - trade.tp_atr_mult
+  - trade.tp_partial_min_notional_usd
+- id: p10_144v
+  file: p10_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.stoch_rsi_smooth2
+  - thresholds.entry.high_conf_volume_mult
+  - thresholds.tp_and_momentum.adx_strong_gt
+  - trade.add_min_confidence
+  - trade.enable_dynamic_sizing
+  - trade.min_notional_usd
+  - trade.tp_partial_pct
+  - trade.trailing_distance_atr
+- id: p11_144v
+  file: p11_144v.yaml
+  axis_count: 8
+  combo: 864
+  two_value_axes: 5
+  three_value_axes: 3
+  paths:
+  - indicators.stoch_rsi_window
+  - thresholds.entry.pullback_min_adx
+  - thresholds.tp_and_momentum.adx_weak_lt
+  - trade.allocation_pct
+  - trade.enable_partial_tp
+  - trade.reef_adx_threshold
+  - trade.trailing_distance_atr_low_conf
+  - trade.trailing_start_atr
+- id: p12_144v
+  file: p12_144v.yaml
+  axis_count: 9
+  combo: 1152
+  two_value_axes: 7
+  three_value_axes: 2
+  paths:
+  - filters.adx_rising_saturation
+  - filters.require_macro_alignment
+  - indicators.vol_sma_window
+  - thresholds.entry.pullback_require_macd_sign
+  - thresholds.tp_and_momentum.rsi_long_strong
+  - trade.breakeven_start_atr
+  - trade.enable_pyramiding
+  - trade.reef_long_rsi_block_gt
+  - trade.trailing_start_atr_low_conf
+- id: p13_144v
+  file: p13_144v.yaml
+  axis_count: 9
+  combo: 1152
+  two_value_axes: 7
+  three_value_axes: 2
+  paths:
+  - filters.enable_anomaly_filter
+  - filters.require_volume_confirmation
+  - indicators.vol_trend_window
+  - thresholds.entry.pullback_rsi_long_min
+  - thresholds.tp_and_momentum.rsi_long_weak
+  - trade.confidence_mult_medium
+  - trade.enable_reef_filter
+  - trade.reef_long_rsi_extreme_gt
+  - trade.tsme_min_profit_atr
+- id: p14_144v
+  file: p14_144v.yaml
+  axis_count: 9
+  combo: 1152
+  two_value_axes: 7
+  three_value_axes: 2
+  paths:
+  - filters.enable_extension_filter
+  - filters.use_stoch_rsi_filter
+  - market_regime.auto_reverse_breadth_high
+  - thresholds.entry.pullback_rsi_short_max
+  - thresholds.tp_and_momentum.rsi_short_strong
+  - trade.enable_rsi_overextension_exit
+  - trade.entry_min_confidence
+  - trade.reef_short_rsi_block_lt
+  - trade.tsme_require_adx_slope_negative
+- id: p15_144v
+  file: p15_144v.yaml
+  axis_count: 9
+  combo: 1152
+  two_value_axes: 7
+  three_value_axes: 2
+  paths:
+  - filters.enable_ranging_filter
+  - filters.vol_confirm_include_prev
+  - market_regime.auto_reverse_breadth_low
+  - thresholds.entry.slow_drift_min_adx
+  - thresholds.tp_and_momentum.rsi_short_weak
+  - trade.enable_ssf_filter
+  - trade.leverage
+  - trade.reef_short_rsi_extreme_lt
+  - trade.use_bbo_for_fills
+- id: p16_144v
+  file: p16_144v.yaml
+  axis_count: 9
+  combo: 1152
+  two_value_axes: 7
+  three_value_axes: 2
+  paths:
+  - filters.require_adx_rising
+  - indicators.ave_avg_atr_window
+  - market_regime.breadth_block_long_below
+  - thresholds.entry.slow_drift_min_slope_pct
+  - trade.add_cooldown_minutes
+  - trade.enable_vol_buffered_trailing
+  - trade.leverage_medium
+  - trade.reentry_cooldown_max_mins
+  - trade.vol_baseline_pct
+- id: p17_144v
+  file: p17_144v.yaml
+  axis_count: 9
+  combo: 1152
+  two_value_axes: 7
+  three_value_axes: 2
+  paths:
+  - filters.require_btc_alignment
+  - market_regime.breadth_block_short_above
+  - market_regime.enable_auto_reverse
+  - thresholds.entry.slow_drift_require_macd_sign
+  - trade.add_min_profit_atr
+  - trade.entry_cooldown_s
+  - trade.max_adds_per_symbol
+  - trade.reentry_cooldown_minutes
+  - trade.vol_scalar_max

--- a/backtester/sweeps/full_144v_17phase/p01_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p01_144v.yaml
@@ -1,0 +1,45 @@
+# p01_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.adx_window
+  values:
+  - 8.0
+  - 14.0
+  - 18.0
+- path: market_regime.enable_regime_filter
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.ave_avg_atr_window
+  values:
+  - 30.0
+  - 60.0
+  - 80.0
+- path: thresholds.entry.slow_drift_rsi_long_min
+  values:
+  - 35.0
+  - 65.0
+- path: trade.adx_sizing_full_adx
+  values:
+  - 28.0
+  - 52.0
+- path: trade.exit_cooldown_s
+  values:
+  - 10.0
+  - 20.0
+- path: trade.min_atr_pct
+  values:
+  - 0.0
+  - 0.003
+  - 0.005
+- path: trade.reverse_entry_signal
+  values:
+  - 0.0
+  - 1.0
+- path: trade.vol_scalar_min
+  values:
+  - 0.35
+  - 0.65

--- a/backtester/sweeps/full_144v_17phase/p02_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p02_144v.yaml
@@ -1,0 +1,41 @@
+# p02_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.atr_window
+  values:
+  - 10.0
+  - 16.0
+  - 20.0
+- path: thresholds.anomaly.ema_fast_dev_pct_gt
+  values:
+  - 0.35
+  - 0.65
+- path: thresholds.entry.macd_hist_entry_mode
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+- path: thresholds.entry.slow_drift_rsi_short_max
+  values:
+  - 35.0
+  - 65.0
+- path: trade.adx_sizing_min_mult
+  values:
+  - 0.42
+  - 0.78
+- path: trade.glitch_atr_mult
+  values:
+  - 8.4
+  - 15.6
+- path: trade.reentry_cooldown_min_mins
+  values:
+  - 30.0
+  - 60.0
+  - 90.0
+- path: trade.rsi_exit_lb_hi_profit_low_conf
+  values:
+  - 0.0
+  - 50.0

--- a/backtester/sweeps/full_144v_17phase/p03_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p03_144v.yaml
@@ -1,0 +1,41 @@
+# p03_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.bb_width_avg_window
+  values:
+  - 15.0
+  - 35.0
+  - 50.0
+- path: thresholds.anomaly.price_change_pct_gt
+  values:
+  - 0.07
+  - 0.13
+- path: thresholds.entry.max_dist_ema_fast
+  values:
+  - 0.02
+  - 0.04
+  - 0.05
+- path: thresholds.ranging.adx_below
+  values:
+  - 14.7
+  - 27.3
+- path: trade.block_exits_on_extreme_dev
+  values:
+  - 0.0
+  - 1.0
+- path: trade.glitch_price_dev_pct
+  values:
+  - 0.28
+  - 0.52
+- path: trade.rsi_exit_lb_hi_profit
+  values:
+  - 21.0
+  - 30.0
+  - 39.0
+- path: trade.rsi_exit_lb_lo_profit
+  values:
+  - 14.0
+  - 26.0

--- a/backtester/sweeps/full_144v_17phase/p04_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p04_144v.yaml
@@ -1,0 +1,41 @@
+# p04_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.bb_window
+  values:
+  - 10.0
+  - 20.0
+  - 30.0
+- path: thresholds.entry.ave_adx_mult
+  values:
+  - 0.875
+  - 1.625
+- path: thresholds.entry.min_adx
+  values:
+  - 10.0
+  - 20.0
+  - 25.0
+- path: thresholds.ranging.bb_width_ratio_below
+  values:
+  - 0.56
+  - 1.04
+- path: trade.breakeven_buffer_atr
+  values:
+  - 0.035
+  - 0.065
+- path: trade.leverage_high
+  values:
+  - 3.5
+  - 6.5
+- path: trade.rsi_exit_lb_lo_profit_low_conf
+  values:
+  - 0.0
+  - 50.0
+- path: trade.rsi_exit_profit_atr_switch
+  values:
+  - 1.05
+  - 1.5
+  - 1.95

--- a/backtester/sweeps/full_144v_17phase/p05_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p05_144v.yaml
@@ -1,0 +1,41 @@
+# p05_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.ema_fast_window
+  values:
+  - 5.0
+  - 10.0
+  - 20.0
+- path: thresholds.entry.ave_atr_ratio_gt
+  values:
+  - 1.05
+  - 1.95
+- path: thresholds.entry.pullback_confidence
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+- path: thresholds.ranging.min_signals
+  values:
+  - 1.0
+  - 3.0
+- path: trade.bump_to_min_notional
+  values:
+  - 0.0
+  - 1.0
+- path: trade.leverage_low
+  values:
+  - 0.7
+  - 1.3
+- path: trade.rsi_exit_ub_hi_profit
+  values:
+  - 49.0
+  - 70.0
+  - 91.0
+- path: trade.rsi_exit_ub_hi_profit_low_conf
+  values:
+  - 0.0
+  - 50.0

--- a/backtester/sweeps/full_144v_17phase/p06_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p06_144v.yaml
@@ -1,0 +1,41 @@
+# p06_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.ema_macro_window
+  values:
+  - 140.0
+  - 200.0
+  - 260.0
+- path: thresholds.entry.ave_enabled
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.slow_drift_slope_window
+  values:
+  - 10.0
+  - 25.0
+  - 40.0
+- path: thresholds.ranging.rsi_high
+  values:
+  - 37.1
+  - 68.9
+- path: trade.confidence_mult_high
+  values:
+  - 0.7
+  - 1.3
+- path: trade.leverage_max_cap
+  values:
+  - 0.0
+  - 1.0
+- path: trade.rsi_exit_ub_lo_profit
+  values:
+  - 56.0
+  - 100.0
+- path: trade.sl_atr_mult
+  values:
+  - 1.0
+  - 2.0
+  - 3.0

--- a/backtester/sweeps/full_144v_17phase/p07_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p07_144v.yaml
@@ -1,0 +1,41 @@
+# p07_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.ema_slow_window
+  values:
+  - 10.0
+  - 30.0
+  - 50.0
+- path: thresholds.entry.btc_adx_override
+  values:
+  - 28.0
+  - 52.0
+- path: thresholds.ranging.rsi_low
+  values:
+  - 32.9
+  - 61.1
+- path: thresholds.tp_and_momentum.tp_mult_strong
+  values:
+  - 4.9
+  - 7.0
+  - 9.1
+- path: trade.confidence_mult_low
+  values:
+  - 0.35
+  - 0.65
+- path: trade.max_entry_orders_per_loop
+  values:
+  - 4.0
+  - 8.0
+- path: trade.rsi_exit_ub_lo_profit_low_conf
+  values:
+  - 0.0
+  - 50.0
+- path: trade.smart_exit_adx_exhaustion_lt
+  values:
+  - 0.0
+  - 15.0
+  - 30.0

--- a/backtester/sweeps/full_144v_17phase/p08_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p08_144v.yaml
@@ -1,0 +1,41 @@
+# p08_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.rsi_window
+  values:
+  - 10.0
+  - 16.0
+  - 20.0
+- path: thresholds.entry.enable_pullback_entries
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.stoch_rsi.block_long_if_k_gt
+  values:
+  - 0.595
+  - 1.105
+- path: thresholds.tp_and_momentum.tp_mult_weak
+  values:
+  - 2.1
+  - 3.0
+  - 3.9
+- path: trade.enable_breakeven_stop
+  values:
+  - 0.0
+  - 1.0
+- path: trade.max_open_positions
+  values:
+  - 14.0
+  - 26.0
+- path: trade.slippage_bps
+  values:
+  - 7.0
+  - 13.0
+- path: trade.smart_exit_adx_exhaustion_lt_low_conf
+  values:
+  - 0.0
+  - 15.0
+  - 30.0

--- a/backtester/sweeps/full_144v_17phase/p09_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p09_144v.yaml
@@ -1,0 +1,41 @@
+# p09_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.stoch_rsi_smooth1
+  values:
+  - 2.0
+  - 4.0
+  - 5.0
+- path: thresholds.entry.enable_slow_drift_entries
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.stoch_rsi.block_short_if_k_lt
+  values:
+  - 0.105
+  - 0.195
+- path: trade.add_fraction_of_base_margin
+  values:
+  - 0.25
+  - 0.75
+  - 1.0
+- path: trade.enable_dynamic_leverage
+  values:
+  - 0.0
+  - 1.0
+- path: trade.max_total_margin_pct
+  values:
+  - 0.42
+  - 0.78
+- path: trade.tp_atr_mult
+  values:
+  - 3.0
+  - 5.5
+  - 8.0
+- path: trade.tp_partial_min_notional_usd
+  values:
+  - 7.0
+  - 13.0

--- a/backtester/sweeps/full_144v_17phase/p10_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p10_144v.yaml
@@ -1,0 +1,41 @@
+# p10_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.stoch_rsi_smooth2
+  values:
+  - 2.0
+  - 4.0
+  - 5.0
+- path: thresholds.entry.high_conf_volume_mult
+  values:
+  - 1.75
+  - 3.25
+- path: thresholds.tp_and_momentum.adx_strong_gt
+  values:
+  - 28.0
+  - 52.0
+- path: trade.add_min_confidence
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+- path: trade.enable_dynamic_sizing
+  values:
+  - 0.0
+  - 1.0
+- path: trade.min_notional_usd
+  values:
+  - 7.0
+  - 13.0
+- path: trade.tp_partial_pct
+  values:
+  - 0.35
+  - 0.65
+- path: trade.trailing_distance_atr
+  values:
+  - 0.3
+  - 0.8
+  - 1.2

--- a/backtester/sweeps/full_144v_17phase/p11_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p11_144v.yaml
@@ -1,0 +1,41 @@
+# p11_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: indicators.stoch_rsi_window
+  values:
+  - 10.0
+  - 16.0
+  - 20.0
+- path: thresholds.entry.pullback_min_adx
+  values:
+  - 15.4
+  - 28.6
+- path: thresholds.tp_and_momentum.adx_weak_lt
+  values:
+  - 21.0
+  - 39.0
+- path: trade.allocation_pct
+  values:
+  - 0.05
+  - 0.2
+  - 0.3
+- path: trade.enable_partial_tp
+  values:
+  - 0.0
+  - 1.0
+- path: trade.reef_adx_threshold
+  values:
+  - 31.5
+  - 58.5
+- path: trade.trailing_distance_atr_low_conf
+  values:
+  - 0.0
+  - 1.0
+- path: trade.trailing_start_atr
+  values:
+  - 0.5
+  - 1.25
+  - 2.0

--- a/backtester/sweeps/full_144v_17phase/p12_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p12_144v.yaml
@@ -1,0 +1,44 @@
+# p12_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: filters.adx_rising_saturation
+  values:
+  - 28.0
+  - 52.0
+- path: filters.require_macro_alignment
+  values:
+  - 0.0
+  - 1.0
+- path: indicators.vol_sma_window
+  values:
+  - 10.0
+  - 20.0
+  - 30.0
+- path: thresholds.entry.pullback_require_macd_sign
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.tp_and_momentum.rsi_long_strong
+  values:
+  - 36.4
+  - 67.6
+- path: trade.breakeven_start_atr
+  values:
+  - 0.3
+  - 0.7
+  - 1.0
+- path: trade.enable_pyramiding
+  values:
+  - 0.0
+  - 1.0
+- path: trade.reef_long_rsi_block_gt
+  values:
+  - 49.0
+  - 91.0
+- path: trade.trailing_start_atr_low_conf
+  values:
+  - 0.0
+  - 1.0

--- a/backtester/sweeps/full_144v_17phase/p13_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p13_144v.yaml
@@ -1,0 +1,44 @@
+# p13_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: filters.enable_anomaly_filter
+  values:
+  - 0.0
+  - 1.0
+- path: filters.require_volume_confirmation
+  values:
+  - 0.0
+  - 1.0
+- path: indicators.vol_trend_window
+  values:
+  - 3.0
+  - 7.0
+  - 10.0
+- path: thresholds.entry.pullback_rsi_long_min
+  values:
+  - 35.0
+  - 65.0
+- path: thresholds.tp_and_momentum.rsi_long_weak
+  values:
+  - 39.2
+  - 72.8
+- path: trade.confidence_mult_medium
+  values:
+  - 0.3
+  - 0.7
+  - 1.0
+- path: trade.enable_reef_filter
+  values:
+  - 0.0
+  - 1.0
+- path: trade.reef_long_rsi_extreme_gt
+  values:
+  - 52.5
+  - 97.5
+- path: trade.tsme_min_profit_atr
+  values:
+  - 0.7
+  - 1.3

--- a/backtester/sweeps/full_144v_17phase/p14_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p14_144v.yaml
@@ -1,0 +1,44 @@
+# p14_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: filters.enable_extension_filter
+  values:
+  - 0.0
+  - 1.0
+- path: filters.use_stoch_rsi_filter
+  values:
+  - 0.0
+  - 1.0
+- path: market_regime.auto_reverse_breadth_high
+  values:
+  - 63.0
+  - 90.0
+  - 100.0
+- path: thresholds.entry.pullback_rsi_short_max
+  values:
+  - 35.0
+  - 65.0
+- path: thresholds.tp_and_momentum.rsi_short_strong
+  values:
+  - 33.6
+  - 62.4
+- path: trade.enable_rsi_overextension_exit
+  values:
+  - 0.0
+  - 1.0
+- path: trade.entry_min_confidence
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+- path: trade.reef_short_rsi_block_lt
+  values:
+  - 21.0
+  - 39.0
+- path: trade.tsme_require_adx_slope_negative
+  values:
+  - 0.0
+  - 1.0

--- a/backtester/sweeps/full_144v_17phase/p15_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p15_144v.yaml
@@ -1,0 +1,44 @@
+# p15_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: filters.enable_ranging_filter
+  values:
+  - 0.0
+  - 1.0
+- path: filters.vol_confirm_include_prev
+  values:
+  - 0.0
+  - 1.0
+- path: market_regime.auto_reverse_breadth_low
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: thresholds.entry.slow_drift_min_adx
+  values:
+  - 7.0
+  - 13.0
+- path: thresholds.tp_and_momentum.rsi_short_weak
+  values:
+  - 30.8
+  - 57.2
+- path: trade.enable_ssf_filter
+  values:
+  - 0.0
+  - 1.0
+- path: trade.leverage
+  values:
+  - 1.0
+  - 3.0
+  - 5.0
+- path: trade.reef_short_rsi_extreme_lt
+  values:
+  - 17.5
+  - 32.5
+- path: trade.use_bbo_for_fills
+  values:
+  - 0.0
+  - 1.0

--- a/backtester/sweeps/full_144v_17phase/p16_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p16_144v.yaml
@@ -1,0 +1,44 @@
+# p16_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: filters.require_adx_rising
+  values:
+  - 0.0
+  - 1.0
+- path: indicators.ave_avg_atr_window
+  values:
+  - 35.0
+  - 65.0
+- path: market_regime.breadth_block_long_below
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: thresholds.entry.slow_drift_min_slope_pct
+  values:
+  - 0.00042
+  - 0.00078
+- path: trade.add_cooldown_minutes
+  values:
+  - 42.0
+  - 78.0
+- path: trade.enable_vol_buffered_trailing
+  values:
+  - 0.0
+  - 1.0
+- path: trade.leverage_medium
+  values:
+  - 2.0
+  - 4.0
+  - 5.0
+- path: trade.reentry_cooldown_max_mins
+  values:
+  - 126.0
+  - 234.0
+- path: trade.vol_baseline_pct
+  values:
+  - 0.007
+  - 0.013

--- a/backtester/sweeps/full_144v_17phase/p17_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p17_144v.yaml
@@ -1,0 +1,44 @@
+# p17_144v
+# Auto-generated from full_144v coverage.
+# Values are reduced for phase-grid practicality.
+initial_balance: 10000.0
+lookback: 200
+axes:
+- path: filters.require_btc_alignment
+  values:
+  - 0.0
+  - 1.0
+- path: market_regime.breadth_block_short_above
+  values:
+  - 63.0
+  - 90.0
+  - 100.0
+- path: market_regime.enable_auto_reverse
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.slow_drift_require_macd_sign
+  values:
+  - 0.0
+  - 1.0
+- path: trade.add_min_profit_atr
+  values:
+  - 0.35
+  - 0.65
+- path: trade.entry_cooldown_s
+  values:
+  - 14.0
+  - 26.0
+- path: trade.max_adds_per_symbol
+  values:
+  - 0.0
+  - 2.0
+  - 3.0
+- path: trade.reentry_cooldown_minutes
+  values:
+  - 42.0
+  - 78.0
+- path: trade.vol_scalar_max
+  values:
+  - 0.7
+  - 1.3

--- a/backtester/sweeps/generate_17phase_144v.py
+++ b/backtester/sweeps/generate_17phase_144v.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Generate a 17-phase sweep set from full_144v coverage.
+
+Design goals:
+- Keep full axis coverage from `full_144v.yaml` (every axis appears once).
+- Keep total grid size near the legacy 17-phase scale (~18k combos per interval).
+- Preserve broader resolution (3-point min/mid/max) on core axes from `full_34axis`
+  plus selected high-impact risk/exit/regime dimensions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class Axis:
+    path: str
+    values: list[float]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    obj = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(obj, dict):
+        raise ValueError(f"invalid YAML root: {path}")
+    return obj
+
+
+def _uniq(values: list[float]) -> list[float]:
+    out: list[float] = []
+    seen: set[float] = set()
+    for raw in values:
+        v = float(raw)
+        if v in seen:
+            continue
+        out.append(v)
+        seen.add(v)
+    return out
+
+
+def _reduce_values(path: str, values: list[float], *, keep_three: set[str]) -> list[float]:
+    vals = _uniq([float(v) for v in values])
+    if not vals:
+        raise ValueError(f"axis has empty values: {path}")
+    if len(vals) <= 2:
+        return vals
+    if path in keep_three:
+        mid = vals[len(vals) // 2]
+        return _uniq([vals[0], mid, vals[-1]])
+    return _uniq([vals[0], vals[-1]])
+
+
+def _combo_count(axes: list[Axis]) -> int:
+    n = 1
+    for axis in axes:
+        n *= len(axis.values)
+    return int(n)
+
+
+def _phase_id(i: int) -> str:
+    return f"p{i:02d}_144v"
+
+
+def _dump_yaml(path: Path, obj: dict[str, Any]) -> None:
+    text = yaml.safe_dump(obj, sort_keys=False)
+    path.write_text(text, encoding="utf-8")
+
+
+def build(
+    *,
+    full_144v_path: Path,
+    full_34_path: Path,
+    out_dir: Path,
+    source_spec_ref: str,
+    reference_spec_ref: str,
+    phase_count: int = 17,
+    max_axes_per_phase: int = 9,
+) -> dict[str, Any]:
+    src_144 = _load_yaml(full_144v_path)
+    src_34 = _load_yaml(full_34_path)
+
+    axes_144 = src_144.get("axes", [])
+    axes_34 = src_34.get("axes", [])
+    if not isinstance(axes_144, list) or not isinstance(axes_34, list):
+        raise ValueError("sweep specs must define `axes` as a list")
+
+    baseline_paths = {
+        str(item.get("path", "")).strip()
+        for item in axes_34
+        if isinstance(item, dict) and str(item.get("path", "")).strip()
+    }
+
+    extra_keep_three = {
+        "trade.smart_exit_adx_exhaustion_lt",
+        "trade.smart_exit_adx_exhaustion_lt_low_conf",
+        "trade.rsi_exit_profit_atr_switch",
+        "trade.rsi_exit_ub_hi_profit",
+        "trade.rsi_exit_lb_hi_profit",
+        "thresholds.tp_and_momentum.tp_mult_strong",
+        "thresholds.tp_and_momentum.tp_mult_weak",
+        "market_regime.breadth_block_short_above",
+        "market_regime.breadth_block_long_below",
+        "market_regime.auto_reverse_breadth_low",
+        "market_regime.auto_reverse_breadth_high",
+        "indicators.ema_macro_window",
+    }
+
+    enum_three = {
+        "trade.entry_min_confidence",
+        "trade.add_min_confidence",
+        "thresholds.entry.pullback_confidence",
+        "thresholds.entry.macd_hist_entry_mode",
+    }
+
+    keep_three = baseline_paths | extra_keep_three | enum_three
+
+    reduced: list[Axis] = []
+    seen_paths: set[str] = set()
+    for item in axes_144:
+        if not isinstance(item, dict):
+            continue
+        path = str(item.get("path", "")).strip()
+        raw_values = item.get("values", [])
+        if not path or not isinstance(raw_values, list):
+            continue
+        if path in seen_paths:
+            raise ValueError(f"duplicate axis path in full_144v: {path}")
+        seen_paths.add(path)
+        values = _reduce_values(path, [float(v) for v in raw_values], keep_three=keep_three)
+        reduced.append(Axis(path=path, values=values))
+
+    if len(reduced) == 0:
+        raise ValueError("no axes found in full_144v")
+
+    phases: list[list[Axis]] = [[] for _ in range(phase_count)]
+    phase_weights = [0.0 for _ in range(phase_count)]
+
+    items = sorted(reduced, key=lambda a: (-len(a.values), a.path))
+    for axis in items:
+        # Prefer the least-loaded phase while respecting max axes per phase.
+        choices = [i for i, arr in enumerate(phases) if len(arr) < max_axes_per_phase]
+        if not choices:
+            # Safety fallback: if constraints are impossible, place in absolute least-loaded phase.
+            choices = list(range(phase_count))
+        idx = min(choices, key=lambda i: (phase_weights[i], len(phases[i])))
+        phases[idx].append(axis)
+        phase_weights[idx] += math.log(len(axis.values))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_phases: list[dict[str, Any]] = []
+    total_combo = 0
+    all_paths_written: set[str] = set()
+
+    for i, arr in enumerate(phases, start=1):
+        arr_sorted = sorted(arr, key=lambda a: a.path)
+        spec = {
+            "initial_balance": float(src_144.get("initial_balance", 10000.0)),
+            "lookback": int(src_144.get("lookback", 200)),
+            "axes": [{"path": a.path, "values": [float(v) for v in a.values]} for a in arr_sorted],
+        }
+        phase_file = out_dir / f"{_phase_id(i)}.yaml"
+        header = (
+            f"# {_phase_id(i)}\n"
+            "# Auto-generated from full_144v coverage.\n"
+            "# Values are reduced for phase-grid practicality.\n"
+        )
+        phase_file.write_text(header + yaml.safe_dump(spec, sort_keys=False), encoding="utf-8")
+
+        combo = _combo_count(arr_sorted)
+        total_combo += combo
+        for axis in arr_sorted:
+            all_paths_written.add(axis.path)
+
+        manifest_phases.append(
+            {
+                "id": _phase_id(i),
+                "file": str(phase_file.name),
+                "axis_count": len(arr_sorted),
+                "combo": combo,
+                "two_value_axes": sum(1 for a in arr_sorted if len(a.values) == 2),
+                "three_value_axes": sum(1 for a in arr_sorted if len(a.values) == 3),
+                "paths": [a.path for a in arr_sorted],
+            }
+        )
+
+    all_paths_src = {a.path for a in reduced}
+    if all_paths_written != all_paths_src:
+        miss = sorted(all_paths_src - all_paths_written)
+        extra = sorted(all_paths_written - all_paths_src)
+        raise ValueError(f"path coverage mismatch: missing={len(miss)} extra={len(extra)}")
+
+    manifest = {
+        "source_spec": str(source_spec_ref),
+        "reference_spec": str(reference_spec_ref),
+        "phase_count": int(phase_count),
+        "total_axes": len(reduced),
+        "total_combo": int(total_combo),
+        "notes": [
+            "All full_144v axes are included once across the 17 phases.",
+            "Most axes use 2-point min/max values; selected key axes use 3-point min/mid/max.",
+            "This keeps runtime near the legacy 17-phase scale while preserving 144v coverage.",
+        ],
+        "phases": manifest_phases,
+    }
+    _dump_yaml(out_dir / "manifest.yaml", manifest)
+    return manifest
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Generate 17-phase 144v sweep specs.")
+    ap.add_argument(
+        "--full-144v",
+        default="backtester/sweeps/full_144v.yaml",
+        help="Path to the full 144v sweep spec.",
+    )
+    ap.add_argument(
+        "--full-34",
+        default="backtester/sweeps/full_34axis.yaml",
+        help="Path to the baseline 34-axis sweep spec.",
+    )
+    ap.add_argument(
+        "--out-dir",
+        default="backtester/sweeps/full_144v_17phase",
+        help="Output directory for generated phase specs.",
+    )
+    ap.add_argument("--phase-count", type=int, default=17, help="Number of phases (default: 17).")
+    ap.add_argument("--max-axes-per-phase", type=int, default=9, help="Max axes per phase.")
+    args = ap.parse_args()
+
+    root = Path(__file__).resolve().parents[2]
+    full_144v = (root / str(args.full_144v)).resolve()
+    full_34 = (root / str(args.full_34)).resolve()
+    out_dir = (root / str(args.out_dir)).resolve()
+
+    manifest = build(
+        full_144v_path=full_144v,
+        full_34_path=full_34,
+        out_dir=out_dir,
+        source_spec_ref=str(args.full_144v),
+        reference_spec_ref=str(args.full_34),
+        phase_count=int(args.phase_count),
+        max_axes_per_phase=int(args.max_axes_per_phase),
+    )
+
+    print(
+        f"Generated {manifest['phase_count']} phases, "
+        f"{manifest['total_axes']} axes, total_combo={manifest['total_combo']}"
+    )
+    for ph in manifest["phases"]:
+        print(
+            f"{ph['id']}: axes={ph['axis_count']} combo={ph['combo']} "
+            f"(2v={ph['two_value_axes']}, 3v={ph['three_value_axes']})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtester/sweeps/run_17phase_144v.sh
+++ b/backtester/sweeps/run_17phase_144v.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 17-phase 144v sweep runner (grid).
+#
+# Default scale:
+# - 17 phases
+# - 17,280 combos per interval
+# - Intervals: 3m, 5m, 15m, 30m
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+BT="./target/release/mei-backtester"
+PHASE_DIR="sweeps/full_144v_17phase"
+MANIFEST="${PHASE_DIR}/manifest.yaml"
+CONFIG="../config/strategy_overrides.yaml"
+OUTDIR="sweep_results/phase144v"
+INTERVALS="3m 5m 15m 30m"
+USE_GPU=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --intervals) INTERVALS="$2"; shift 2 ;;
+        --outdir) OUTDIR="$2"; shift 2 ;;
+        --cpu) USE_GPU=0; shift ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+if [[ ! -f "$BT" ]]; then
+    echo "ERROR: Backtester not found at $BT"
+    echo "Build with: cargo build --release -p bt-cli --features gpu"
+    exit 1
+fi
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: Manifest not found at $MANIFEST"
+    echo "Generate with: python3 sweeps/generate_17phase_144v.py"
+    exit 1
+fi
+if [[ ! -f "$CONFIG" ]]; then
+    echo "ERROR: Strategy config not found at $CONFIG"
+    exit 1
+fi
+
+if [[ "$USE_GPU" -eq 1 ]]; then
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:/usr/lib/wsl/lib"
+fi
+
+PHASE_INFO_JSON="$(python3 - "$MANIFEST" <<'PY'
+import json, sys, yaml
+m = yaml.safe_load(open(sys.argv[1], "r", encoding="utf-8").read()) or {}
+ph = m.get("phases", [])
+out = []
+for p in ph:
+    out.append({
+        "id": str(p.get("id", "")),
+        "file": str(p.get("file", "")),
+        "combo": int(p.get("combo", 0)),
+    })
+print(json.dumps(out))
+PY
+)"
+
+TOTAL_COMBOS="$(python3 - "$MANIFEST" <<'PY'
+import sys, yaml
+m = yaml.safe_load(open(sys.argv[1], "r", encoding="utf-8").read()) or {}
+print(int(m.get("total_combo", 0)))
+PY
+)"
+
+mkdir -p "$OUTDIR"
+
+echo "=============================================================="
+echo " 17-phase 144v sweep"
+echo " combos per interval: ${TOTAL_COMBOS}"
+echo " intervals: ${INTERVALS}"
+echo " mode: $( [[ "$USE_GPU" -eq 1 ]] && echo GPU || echo CPU )"
+echo "=============================================================="
+
+START_TIME=$(date +%s)
+TOTAL_RUNS=0
+
+for interval in $INTERVALS; do
+    echo ""
+    echo "Interval: ${interval}"
+    echo "--------------------------------------------------------------"
+    while IFS=$'\t' read -r phase_id phase_file phase_combo; do
+        spec_path="${PHASE_DIR}/${phase_file}"
+        out_jsonl="${OUTDIR}/${phase_id}_${interval}.jsonl"
+        if [[ ! -f "$spec_path" ]]; then
+            echo "[SKIP] ${phase_id}: missing ${spec_path}"
+            continue
+        fi
+
+        echo -n "[RUN] ${phase_id} (${phase_combo} combos) ... "
+        phase_start=$(date +%s)
+
+        if [[ "$USE_GPU" -eq 1 ]]; then
+            "$BT" sweep \
+                --config "$CONFIG" \
+                --sweep-spec "$spec_path" \
+                --interval "$interval" \
+                --gpu \
+                --output "$out_jsonl" \
+                --top-n 0 >/dev/null 2>&1
+        else
+            "$BT" sweep \
+                --config "$CONFIG" \
+                --sweep-spec "$spec_path" \
+                --interval "$interval" \
+                --output "$out_jsonl" \
+                --top-n 0 >/dev/null 2>&1
+        fi
+
+        phase_end=$(date +%s)
+        elapsed=$((phase_end - phase_start))
+        lines=$(wc -l < "$out_jsonl" 2>/dev/null || echo 0)
+        echo "${lines} done in ${elapsed}s"
+        TOTAL_RUNS=$((TOTAL_RUNS + lines))
+    done < <(
+        python3 - "$PHASE_INFO_JSON" <<'PY'
+import json, sys
+for p in json.loads(sys.argv[1]):
+    print(f"{p['id']}\t{p['file']}\t{p['combo']}")
+PY
+    )
+done
+
+END_TIME=$(date +%s)
+ELAPSED=$((END_TIME - START_TIME))
+
+echo ""
+echo "=============================================================="
+echo "Complete"
+echo " total runs: ${TOTAL_RUNS}"
+echo " elapsed: ${ELAPSED}s"
+echo " output: ${OUTDIR}"
+echo "=============================================================="


### PR DESCRIPTION
## Summary
- add a generated 17-phase sweep pack derived from `backtester/sweeps/full_144v.yaml`
- preserve full 144v axis coverage (143 axes) while reducing per-axis value density for practical grid runs
- add `backtester/sweeps/run_17phase_144v.sh` to execute all phases across selected intervals
- add `backtester/sweeps/generate_17phase_144v.py` for deterministic regeneration

## Scale
- phases: 17
- axes covered: 143 (all `full_144v` axes, each exactly once)
- total combos per interval: 17,280

## Validation
- `python3 -m py_compile backtester/sweeps/generate_17phase_144v.py`
- `bash -n backtester/sweeps/run_17phase_144v.sh`
- manifest/path integrity check confirms 143/143 coverage and combo sum = 17,280
- `cargo check -p bt-cli`
