### PR TITLE
feat(backtester): tune 17-phase 144v pack to ~100k grid

### DIFF
--- a/backtester/sweeps/full_144v_17phase/README.md
+++ b/backtester/sweeps/full_144v_17phase/README.md
@@ -7,13 +7,14 @@ This directory contains a phase-based grid sweep pack generated from
 
 - `full_144v.yaml` gives broad parameter coverage, but the full cartesian grid is intractable.
 - This pack keeps **all 143 axes** while reducing value density per axis for practical grid runs.
-- Total scale stays near the legacy 17-phase workflow.
+- Total scale is auto-tuned to a practical CPU grid target.
 
 ## Current scale
 
 - Phases: **17**
 - Axes covered: **143** (all `full_144v` axes, each exactly once)
-- Total combos per interval: **17,280**
+- Default target combos per interval: **100,000**
+- Current generated combos per interval: **100,602**
 
 ## Files
 
@@ -25,7 +26,7 @@ This directory contains a phase-based grid sweep pack generated from
 From repo root:
 
 ```bash
-python3 backtester/sweeps/generate_17phase_144v.py
+python3 backtester/sweeps/generate_17phase_144v.py --target-combo 100000
 ```
 
 This rewrites all phase files and `manifest.yaml` deterministically.

--- a/backtester/sweeps/full_144v_17phase/manifest.yaml
+++ b/backtester/sweeps/full_144v_17phase/manifest.yaml
@@ -2,271 +2,294 @@ source_spec: backtester/sweeps/full_144v.yaml
 reference_spec: backtester/sweeps/full_34axis.yaml
 phase_count: 17
 total_axes: 143
-total_combo: 17280
+base_combo: 17280
+target_combo: 100000
+achieved_combo: 100602
+total_combo: 100602
+four_value_axes_total: 7
+three_value_axes_total: 106
+two_value_axes_total: 30
 notes:
 - All full_144v axes are included once across the 17 phases.
-- Most axes use 2-point min/max values; selected key axes use 3-point min/mid/max.
-- This keeps runtime near the legacy 17-phase scale while preserving 144v coverage.
+- Most axes use 2-point min/max values; selected axes use 3-point or 4-point samples.
+- Auto-tuning promotes additional 3/4-point axes until the target combo is reached.
 phases:
 - id: p01_144v
   file: p01_144v.yaml
-  axis_count: 9
-  combo: 1728
-  two_value_axes: 6
-  three_value_axes: 3
+  axis_count: 8
+  combo: 5832
+  two_value_axes: 1
+  three_value_axes: 6
+  four_value_axes: 1
   paths:
   - indicators.adx_window
-  - market_regime.enable_regime_filter
-  - thresholds.entry.ave_avg_atr_window
-  - thresholds.entry.slow_drift_rsi_long_min
-  - trade.adx_sizing_full_adx
-  - trade.exit_cooldown_s
-  - trade.min_atr_pct
-  - trade.reverse_entry_signal
+  - thresholds.entry.max_dist_ema_fast
+  - thresholds.stoch_rsi.block_short_if_k_lt
+  - trade.breakeven_start_atr
+  - trade.enable_pyramiding
+  - trade.max_total_margin_pct
+  - trade.rsi_exit_ub_hi_profit_low_conf
   - trade.vol_scalar_min
 - id: p02_144v
   file: p02_144v.yaml
-  axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  axis_count: 9
+  combo: 7776
+  two_value_axes: 3
+  three_value_axes: 5
+  four_value_axes: 1
   paths:
+  - filters.enable_anomaly_filter
+  - filters.require_volume_confirmation
   - indicators.atr_window
-  - thresholds.anomaly.ema_fast_dev_pct_gt
-  - thresholds.entry.macd_hist_entry_mode
-  - thresholds.entry.slow_drift_rsi_short_max
-  - trade.adx_sizing_min_mult
-  - trade.glitch_atr_mult
-  - trade.reentry_cooldown_min_mins
-  - trade.rsi_exit_lb_hi_profit_low_conf
+  - thresholds.entry.min_adx
+  - thresholds.tp_and_momentum.adx_strong_gt
+  - trade.confidence_mult_high
+  - trade.enable_reef_filter
+  - trade.min_atr_pct
+  - trade.rsi_exit_ub_lo_profit
 - id: p03_144v
   file: p03_144v.yaml
-  axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  axis_count: 9
+  combo: 7776
+  two_value_axes: 3
+  three_value_axes: 5
+  four_value_axes: 1
   paths:
+  - filters.enable_extension_filter
+  - filters.use_stoch_rsi_filter
   - indicators.bb_width_avg_window
-  - thresholds.anomaly.price_change_pct_gt
-  - thresholds.entry.max_dist_ema_fast
-  - thresholds.ranging.adx_below
-  - trade.block_exits_on_extreme_dev
-  - trade.glitch_price_dev_pct
-  - trade.rsi_exit_lb_hi_profit
-  - trade.rsi_exit_lb_lo_profit
+  - thresholds.entry.pullback_confidence
+  - thresholds.tp_and_momentum.adx_weak_lt
+  - trade.confidence_mult_low
+  - trade.enable_rsi_overextension_exit
+  - trade.min_notional_usd
+  - trade.rsi_exit_ub_lo_profit_low_conf
 - id: p04_144v
   file: p04_144v.yaml
-  axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  axis_count: 9
+  combo: 7776
+  two_value_axes: 3
+  three_value_axes: 5
+  four_value_axes: 1
   paths:
+  - filters.enable_ranging_filter
+  - filters.vol_confirm_include_prev
   - indicators.bb_window
-  - thresholds.entry.ave_adx_mult
-  - thresholds.entry.min_adx
-  - thresholds.ranging.bb_width_ratio_below
-  - trade.breakeven_buffer_atr
-  - trade.leverage_high
-  - trade.rsi_exit_lb_lo_profit_low_conf
-  - trade.rsi_exit_profit_atr_switch
+  - thresholds.entry.pullback_min_adx
+  - thresholds.tp_and_momentum.rsi_long_strong
+  - trade.confidence_mult_medium
+  - trade.enable_ssf_filter
+  - trade.reef_adx_threshold
+  - trade.sl_atr_mult
 - id: p05_144v
   file: p05_144v.yaml
-  axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  axis_count: 9
+  combo: 7776
+  two_value_axes: 3
+  three_value_axes: 5
+  four_value_axes: 1
   paths:
+  - filters.require_adx_rising
   - indicators.ema_fast_window
-  - thresholds.entry.ave_atr_ratio_gt
-  - thresholds.entry.pullback_confidence
-  - thresholds.ranging.min_signals
-  - trade.bump_to_min_notional
-  - trade.leverage_low
-  - trade.rsi_exit_ub_hi_profit
-  - trade.rsi_exit_ub_hi_profit_low_conf
+  - market_regime.enable_auto_reverse
+  - thresholds.entry.pullback_rsi_long_min
+  - thresholds.tp_and_momentum.rsi_long_weak
+  - trade.enable_vol_buffered_trailing
+  - trade.entry_cooldown_s
+  - trade.reef_long_rsi_block_gt
+  - trade.slippage_bps
 - id: p06_144v
   file: p06_144v.yaml
-  axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  axis_count: 9
+  combo: 7776
+  two_value_axes: 3
+  three_value_axes: 5
+  four_value_axes: 1
   paths:
-  - indicators.ema_macro_window
-  - thresholds.entry.ave_enabled
-  - thresholds.entry.slow_drift_slope_window
-  - thresholds.ranging.rsi_high
-  - trade.confidence_mult_high
-  - trade.leverage_max_cap
-  - trade.rsi_exit_ub_lo_profit
-  - trade.sl_atr_mult
+  - filters.require_btc_alignment
+  - indicators.ema_slow_window
+  - market_regime.enable_regime_filter
+  - thresholds.entry.pullback_rsi_short_max
+  - thresholds.tp_and_momentum.rsi_short_strong
+  - trade.entry_min_confidence
+  - trade.reef_long_rsi_extreme_gt
+  - trade.reverse_entry_signal
+  - trade.smart_exit_adx_exhaustion_lt
 - id: p07_144v
   file: p07_144v.yaml
-  axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  axis_count: 9
+  combo: 7776
+  two_value_axes: 3
+  three_value_axes: 5
+  four_value_axes: 1
   paths:
-  - indicators.ema_slow_window
-  - thresholds.entry.btc_adx_override
-  - thresholds.ranging.rsi_low
-  - thresholds.tp_and_momentum.tp_mult_strong
-  - trade.confidence_mult_low
-  - trade.max_entry_orders_per_loop
-  - trade.rsi_exit_ub_lo_profit_low_conf
-  - trade.smart_exit_adx_exhaustion_lt
+  - filters.require_macro_alignment
+  - indicators.rsi_window
+  - thresholds.entry.ave_enabled
+  - thresholds.entry.slow_drift_min_adx
+  - thresholds.tp_and_momentum.rsi_short_weak
+  - trade.exit_cooldown_s
+  - trade.reef_short_rsi_block_lt
+  - trade.smart_exit_adx_exhaustion_lt_low_conf
+  - trade.tsme_require_adx_slope_negative
 - id: p08_144v
   file: p08_144v.yaml
-  axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  axis_count: 9
+  combo: 8748
+  two_value_axes: 2
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - indicators.rsi_window
+  - filters.adx_rising_saturation
+  - market_regime.breadth_block_long_below
   - thresholds.entry.enable_pullback_entries
-  - thresholds.stoch_rsi.block_long_if_k_gt
-  - thresholds.tp_and_momentum.tp_mult_weak
-  - trade.enable_breakeven_stop
-  - trade.max_open_positions
-  - trade.slippage_bps
-  - trade.smart_exit_adx_exhaustion_lt_low_conf
+  - thresholds.entry.slow_drift_min_slope_pct
+  - thresholds.tp_and_momentum.tp_mult_strong
+  - trade.glitch_atr_mult
+  - trade.reef_short_rsi_extreme_lt
+  - trade.tp_atr_mult
+  - trade.use_bbo_for_fills
 - id: p09_144v
   file: p09_144v.yaml
   axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  combo: 4374
+  two_value_axes: 1
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - indicators.stoch_rsi_smooth1
+  - indicators.ave_avg_atr_window
+  - market_regime.breadth_block_short_above
   - thresholds.entry.enable_slow_drift_entries
-  - thresholds.stoch_rsi.block_short_if_k_lt
-  - trade.add_fraction_of_base_margin
-  - trade.enable_dynamic_leverage
-  - trade.max_total_margin_pct
-  - trade.tp_atr_mult
+  - thresholds.entry.slow_drift_rsi_long_min
+  - thresholds.tp_and_momentum.tp_mult_weak
+  - trade.glitch_price_dev_pct
+  - trade.reentry_cooldown_max_mins
   - trade.tp_partial_min_notional_usd
 - id: p10_144v
   file: p10_144v.yaml
   axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  combo: 4374
+  two_value_axes: 1
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - indicators.stoch_rsi_smooth2
-  - thresholds.entry.high_conf_volume_mult
-  - thresholds.tp_and_momentum.adx_strong_gt
-  - trade.add_min_confidence
-  - trade.enable_dynamic_sizing
-  - trade.min_notional_usd
+  - indicators.ema_macro_window
+  - thresholds.anomaly.ema_fast_dev_pct_gt
+  - thresholds.entry.pullback_require_macd_sign
+  - thresholds.entry.slow_drift_rsi_short_max
+  - trade.add_cooldown_minutes
+  - trade.leverage
+  - trade.reentry_cooldown_min_mins
   - trade.tp_partial_pct
-  - trade.trailing_distance_atr
 - id: p11_144v
   file: p11_144v.yaml
   axis_count: 8
-  combo: 864
-  two_value_axes: 5
-  three_value_axes: 3
+  combo: 4374
+  two_value_axes: 1
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - indicators.stoch_rsi_window
-  - thresholds.entry.pullback_min_adx
-  - thresholds.tp_and_momentum.adx_weak_lt
-  - trade.allocation_pct
-  - trade.enable_partial_tp
-  - trade.reef_adx_threshold
-  - trade.trailing_distance_atr_low_conf
-  - trade.trailing_start_atr
+  - indicators.stoch_rsi_smooth1
+  - thresholds.anomaly.price_change_pct_gt
+  - thresholds.entry.slow_drift_require_macd_sign
+  - thresholds.entry.slow_drift_slope_window
+  - trade.add_fraction_of_base_margin
+  - trade.leverage_high
+  - trade.reentry_cooldown_minutes
+  - trade.trailing_distance_atr
 - id: p12_144v
   file: p12_144v.yaml
-  axis_count: 9
-  combo: 1152
-  two_value_axes: 7
-  three_value_axes: 2
+  axis_count: 8
+  combo: 4374
+  two_value_axes: 1
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - filters.adx_rising_saturation
-  - filters.require_macro_alignment
-  - indicators.vol_sma_window
-  - thresholds.entry.pullback_require_macd_sign
-  - thresholds.tp_and_momentum.rsi_long_strong
-  - trade.breakeven_start_atr
-  - trade.enable_pyramiding
-  - trade.reef_long_rsi_block_gt
-  - trade.trailing_start_atr_low_conf
+  - indicators.stoch_rsi_smooth2
+  - thresholds.entry.ave_adx_mult
+  - thresholds.ranging.adx_below
+  - trade.add_min_confidence
+  - trade.block_exits_on_extreme_dev
+  - trade.leverage_low
+  - trade.rsi_exit_lb_hi_profit
+  - trade.trailing_distance_atr_low_conf
 - id: p13_144v
   file: p13_144v.yaml
-  axis_count: 9
-  combo: 1152
-  two_value_axes: 7
-  three_value_axes: 2
+  axis_count: 8
+  combo: 4374
+  two_value_axes: 1
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - filters.enable_anomaly_filter
-  - filters.require_volume_confirmation
-  - indicators.vol_trend_window
-  - thresholds.entry.pullback_rsi_long_min
-  - thresholds.tp_and_momentum.rsi_long_weak
-  - trade.confidence_mult_medium
-  - trade.enable_reef_filter
-  - trade.reef_long_rsi_extreme_gt
-  - trade.tsme_min_profit_atr
+  - indicators.stoch_rsi_window
+  - thresholds.entry.ave_atr_ratio_gt
+  - thresholds.ranging.bb_width_ratio_below
+  - trade.add_min_profit_atr
+  - trade.bump_to_min_notional
+  - trade.leverage_max_cap
+  - trade.rsi_exit_lb_hi_profit_low_conf
+  - trade.trailing_start_atr
 - id: p14_144v
   file: p14_144v.yaml
-  axis_count: 9
-  combo: 1152
-  two_value_axes: 7
-  three_value_axes: 2
+  axis_count: 8
+  combo: 4374
+  two_value_axes: 1
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - filters.enable_extension_filter
-  - filters.use_stoch_rsi_filter
-  - market_regime.auto_reverse_breadth_high
-  - thresholds.entry.pullback_rsi_short_max
-  - thresholds.tp_and_momentum.rsi_short_strong
-  - trade.enable_rsi_overextension_exit
-  - trade.entry_min_confidence
-  - trade.reef_short_rsi_block_lt
-  - trade.tsme_require_adx_slope_negative
+  - indicators.vol_sma_window
+  - thresholds.entry.ave_avg_atr_window
+  - thresholds.ranging.min_signals
+  - trade.adx_sizing_full_adx
+  - trade.enable_breakeven_stop
+  - trade.leverage_medium
+  - trade.rsi_exit_lb_lo_profit
+  - trade.trailing_start_atr_low_conf
 - id: p15_144v
   file: p15_144v.yaml
-  axis_count: 9
-  combo: 1152
-  two_value_axes: 7
-  three_value_axes: 2
+  axis_count: 8
+  combo: 4374
+  two_value_axes: 1
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - filters.enable_ranging_filter
-  - filters.vol_confirm_include_prev
-  - market_regime.auto_reverse_breadth_low
-  - thresholds.entry.slow_drift_min_adx
-  - thresholds.tp_and_momentum.rsi_short_weak
-  - trade.enable_ssf_filter
-  - trade.leverage
-  - trade.reef_short_rsi_extreme_lt
-  - trade.use_bbo_for_fills
+  - indicators.vol_trend_window
+  - thresholds.entry.btc_adx_override
+  - thresholds.ranging.rsi_high
+  - trade.adx_sizing_min_mult
+  - trade.enable_dynamic_leverage
+  - trade.max_adds_per_symbol
+  - trade.rsi_exit_lb_lo_profit_low_conf
+  - trade.tsme_min_profit_atr
 - id: p16_144v
   file: p16_144v.yaml
-  axis_count: 9
-  combo: 1152
-  two_value_axes: 7
-  three_value_axes: 2
+  axis_count: 8
+  combo: 4374
+  two_value_axes: 1
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - filters.require_adx_rising
-  - indicators.ave_avg_atr_window
-  - market_regime.breadth_block_long_below
-  - thresholds.entry.slow_drift_min_slope_pct
-  - trade.add_cooldown_minutes
-  - trade.enable_vol_buffered_trailing
-  - trade.leverage_medium
-  - trade.reentry_cooldown_max_mins
+  - market_regime.auto_reverse_breadth_high
+  - thresholds.entry.high_conf_volume_mult
+  - thresholds.ranging.rsi_low
+  - trade.allocation_pct
+  - trade.enable_dynamic_sizing
+  - trade.max_entry_orders_per_loop
+  - trade.rsi_exit_profit_atr_switch
   - trade.vol_baseline_pct
 - id: p17_144v
   file: p17_144v.yaml
-  axis_count: 9
-  combo: 1152
-  two_value_axes: 7
-  three_value_axes: 2
+  axis_count: 8
+  combo: 4374
+  two_value_axes: 1
+  three_value_axes: 7
+  four_value_axes: 0
   paths:
-  - filters.require_btc_alignment
-  - market_regime.breadth_block_short_above
-  - market_regime.enable_auto_reverse
-  - thresholds.entry.slow_drift_require_macd_sign
-  - trade.add_min_profit_atr
-  - trade.entry_cooldown_s
-  - trade.max_adds_per_symbol
-  - trade.reentry_cooldown_minutes
+  - market_regime.auto_reverse_breadth_low
+  - thresholds.entry.macd_hist_entry_mode
+  - thresholds.stoch_rsi.block_long_if_k_gt
+  - trade.breakeven_buffer_atr
+  - trade.enable_partial_tp
+  - trade.max_open_positions
+  - trade.rsi_exit_ub_hi_profit
   - trade.vol_scalar_max

--- a/backtester/sweeps/full_144v_17phase/p01_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p01_144v.yaml
@@ -7,39 +7,40 @@ axes:
 - path: indicators.adx_window
   values:
   - 8.0
+  - 12.0
   - 14.0
   - 18.0
-- path: market_regime.enable_regime_filter
+- path: thresholds.entry.max_dist_ema_fast
+  values:
+  - 0.02
+  - 0.04
+  - 0.05
+- path: thresholds.stoch_rsi.block_short_if_k_lt
+  values:
+  - 0.105
+  - 0.15
+  - 0.195
+- path: trade.breakeven_start_atr
+  values:
+  - 0.3
+  - 0.7
+  - 1.0
+- path: trade.enable_pyramiding
   values:
   - 0.0
   - 1.0
-- path: thresholds.entry.ave_avg_atr_window
+- path: trade.max_total_margin_pct
   values:
+  - 0.42
+  - 0.6
+  - 0.78
+- path: trade.rsi_exit_ub_hi_profit_low_conf
+  values:
+  - 0.0
   - 30.0
-  - 60.0
-  - 80.0
-- path: thresholds.entry.slow_drift_rsi_long_min
-  values:
-  - 35.0
-  - 65.0
-- path: trade.adx_sizing_full_adx
-  values:
-  - 28.0
-  - 52.0
-- path: trade.exit_cooldown_s
-  values:
-  - 10.0
-  - 20.0
-- path: trade.min_atr_pct
-  values:
-  - 0.0
-  - 0.003
-  - 0.005
-- path: trade.reverse_entry_signal
-  values:
-  - 0.0
-  - 1.0
+  - 50.0
 - path: trade.vol_scalar_min
   values:
   - 0.35
+  - 0.5
   - 0.65

--- a/backtester/sweeps/full_144v_17phase/p02_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p02_144v.yaml
@@ -4,38 +4,46 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: indicators.atr_window
-  values:
-  - 10.0
-  - 16.0
-  - 20.0
-- path: thresholds.anomaly.ema_fast_dev_pct_gt
-  values:
-  - 0.35
-  - 0.65
-- path: thresholds.entry.macd_hist_entry_mode
+- path: filters.enable_anomaly_filter
   values:
   - 0.0
   - 1.0
-  - 2.0
-- path: thresholds.entry.slow_drift_rsi_short_max
-  values:
-  - 35.0
-  - 65.0
-- path: trade.adx_sizing_min_mult
-  values:
-  - 0.42
-  - 0.78
-- path: trade.glitch_atr_mult
-  values:
-  - 8.4
-  - 15.6
-- path: trade.reentry_cooldown_min_mins
-  values:
-  - 30.0
-  - 60.0
-  - 90.0
-- path: trade.rsi_exit_lb_hi_profit_low_conf
+- path: filters.require_volume_confirmation
   values:
   - 0.0
-  - 50.0
+  - 1.0
+- path: indicators.atr_window
+  values:
+  - 10.0
+  - 14.0
+  - 16.0
+  - 20.0
+- path: thresholds.entry.min_adx
+  values:
+  - 10.0
+  - 20.0
+  - 25.0
+- path: thresholds.tp_and_momentum.adx_strong_gt
+  values:
+  - 28.0
+  - 40.0
+  - 52.0
+- path: trade.confidence_mult_high
+  values:
+  - 0.7
+  - 1.0
+  - 1.3
+- path: trade.enable_reef_filter
+  values:
+  - 0.0
+  - 1.0
+- path: trade.min_atr_pct
+  values:
+  - 0.0
+  - 0.002
+  - 0.005
+- path: trade.rsi_exit_ub_lo_profit
+  values:
+  - 56.0
+  - 80.0
+  - 100.0

--- a/backtester/sweeps/full_144v_17phase/p03_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p03_144v.yaml
@@ -4,38 +4,46 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: indicators.bb_width_avg_window
-  values:
-  - 15.0
-  - 35.0
-  - 50.0
-- path: thresholds.anomaly.price_change_pct_gt
-  values:
-  - 0.07
-  - 0.13
-- path: thresholds.entry.max_dist_ema_fast
-  values:
-  - 0.02
-  - 0.04
-  - 0.05
-- path: thresholds.ranging.adx_below
-  values:
-  - 14.7
-  - 27.3
-- path: trade.block_exits_on_extreme_dev
+- path: filters.enable_extension_filter
   values:
   - 0.0
   - 1.0
-- path: trade.glitch_price_dev_pct
+- path: filters.use_stoch_rsi_filter
   values:
-  - 0.28
-  - 0.52
-- path: trade.rsi_exit_lb_hi_profit
+  - 0.0
+  - 1.0
+- path: indicators.bb_width_avg_window
+  values:
+  - 15.0
+  - 25.0
+  - 40.0
+  - 50.0
+- path: thresholds.entry.pullback_confidence
+  values:
+  - 0.0
+  - 1.0
+  - 2.0
+- path: thresholds.tp_and_momentum.adx_weak_lt
   values:
   - 21.0
   - 30.0
   - 39.0
-- path: trade.rsi_exit_lb_lo_profit
+- path: trade.confidence_mult_low
   values:
-  - 14.0
-  - 26.0
+  - 0.35
+  - 0.5
+  - 0.65
+- path: trade.enable_rsi_overextension_exit
+  values:
+  - 0.0
+  - 1.0
+- path: trade.min_notional_usd
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: trade.rsi_exit_ub_lo_profit_low_conf
+  values:
+  - 0.0
+  - 30.0
+  - 50.0

--- a/backtester/sweeps/full_144v_17phase/p04_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p04_144v.yaml
@@ -4,38 +4,46 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
+- path: filters.enable_ranging_filter
+  values:
+  - 0.0
+  - 1.0
+- path: filters.vol_confirm_include_prev
+  values:
+  - 0.0
+  - 1.0
 - path: indicators.bb_window
   values:
   - 10.0
-  - 20.0
-  - 30.0
-- path: thresholds.entry.ave_adx_mult
-  values:
-  - 0.875
-  - 1.625
-- path: thresholds.entry.min_adx
-  values:
-  - 10.0
-  - 20.0
+  - 15.0
   - 25.0
-- path: thresholds.ranging.bb_width_ratio_below
+  - 30.0
+- path: thresholds.entry.pullback_min_adx
   values:
-  - 0.56
-  - 1.04
-- path: trade.breakeven_buffer_atr
+  - 15.4
+  - 22.0
+  - 28.6
+- path: thresholds.tp_and_momentum.rsi_long_strong
   values:
-  - 0.035
-  - 0.065
-- path: trade.leverage_high
+  - 36.4
+  - 52.0
+  - 67.6
+- path: trade.confidence_mult_medium
   values:
-  - 3.5
-  - 6.5
-- path: trade.rsi_exit_lb_lo_profit_low_conf
+  - 0.3
+  - 0.7
+  - 1.0
+- path: trade.enable_ssf_filter
   values:
   - 0.0
-  - 50.0
-- path: trade.rsi_exit_profit_atr_switch
+  - 1.0
+- path: trade.reef_adx_threshold
   values:
-  - 1.05
-  - 1.5
-  - 1.95
+  - 31.5
+  - 45.0
+  - 58.5
+- path: trade.sl_atr_mult
+  values:
+  - 1.0
+  - 2.0
+  - 3.0

--- a/backtester/sweeps/full_144v_17phase/p05_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p05_144v.yaml
@@ -4,38 +4,46 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
+- path: filters.require_adx_rising
+  values:
+  - 0.0
+  - 1.0
 - path: indicators.ema_fast_window
   values:
   - 5.0
-  - 10.0
+  - 8.0
+  - 14.0
   - 20.0
-- path: thresholds.entry.ave_atr_ratio_gt
-  values:
-  - 1.05
-  - 1.95
-- path: thresholds.entry.pullback_confidence
+- path: market_regime.enable_auto_reverse
   values:
   - 0.0
   - 1.0
-  - 2.0
-- path: thresholds.ranging.min_signals
+- path: thresholds.entry.pullback_rsi_long_min
   values:
-  - 1.0
-  - 3.0
-- path: trade.bump_to_min_notional
+  - 35.0
+  - 50.0
+  - 65.0
+- path: thresholds.tp_and_momentum.rsi_long_weak
+  values:
+  - 39.2
+  - 56.0
+  - 72.8
+- path: trade.enable_vol_buffered_trailing
   values:
   - 0.0
   - 1.0
-- path: trade.leverage_low
+- path: trade.entry_cooldown_s
   values:
-  - 0.7
-  - 1.3
-- path: trade.rsi_exit_ub_hi_profit
+  - 14.0
+  - 20.0
+  - 26.0
+- path: trade.reef_long_rsi_block_gt
   values:
   - 49.0
   - 70.0
   - 91.0
-- path: trade.rsi_exit_ub_hi_profit_low_conf
+- path: trade.slippage_bps
   values:
-  - 0.0
-  - 50.0
+  - 7.0
+  - 10.0
+  - 13.0

--- a/backtester/sweeps/full_144v_17phase/p06_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p06_144v.yaml
@@ -4,38 +4,46 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: indicators.ema_macro_window
-  values:
-  - 140.0
-  - 200.0
-  - 260.0
-- path: thresholds.entry.ave_enabled
+- path: filters.require_btc_alignment
   values:
   - 0.0
   - 1.0
-- path: thresholds.entry.slow_drift_slope_window
+- path: indicators.ema_slow_window
   values:
   - 10.0
   - 25.0
-  - 40.0
-- path: thresholds.ranging.rsi_high
-  values:
-  - 37.1
-  - 68.9
-- path: trade.confidence_mult_high
-  values:
-  - 0.7
-  - 1.3
-- path: trade.leverage_max_cap
+  - 35.0
+  - 50.0
+- path: market_regime.enable_regime_filter
   values:
   - 0.0
   - 1.0
-- path: trade.rsi_exit_ub_lo_profit
+- path: thresholds.entry.pullback_rsi_short_max
   values:
-  - 56.0
-  - 100.0
-- path: trade.sl_atr_mult
+  - 35.0
+  - 50.0
+  - 65.0
+- path: thresholds.tp_and_momentum.rsi_short_strong
   values:
+  - 33.6
+  - 48.0
+  - 62.4
+- path: trade.entry_min_confidence
+  values:
+  - 0.0
   - 1.0
   - 2.0
-  - 3.0
+- path: trade.reef_long_rsi_extreme_gt
+  values:
+  - 52.5
+  - 75.0
+  - 97.5
+- path: trade.reverse_entry_signal
+  values:
+  - 0.0
+  - 1.0
+- path: trade.smart_exit_adx_exhaustion_lt
+  values:
+  - 0.0
+  - 15.0
+  - 30.0

--- a/backtester/sweeps/full_144v_17phase/p07_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p07_144v.yaml
@@ -4,38 +4,46 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: indicators.ema_slow_window
-  values:
-  - 10.0
-  - 30.0
-  - 50.0
-- path: thresholds.entry.btc_adx_override
-  values:
-  - 28.0
-  - 52.0
-- path: thresholds.ranging.rsi_low
-  values:
-  - 32.9
-  - 61.1
-- path: thresholds.tp_and_momentum.tp_mult_strong
-  values:
-  - 4.9
-  - 7.0
-  - 9.1
-- path: trade.confidence_mult_low
-  values:
-  - 0.35
-  - 0.65
-- path: trade.max_entry_orders_per_loop
-  values:
-  - 4.0
-  - 8.0
-- path: trade.rsi_exit_ub_lo_profit_low_conf
+- path: filters.require_macro_alignment
   values:
   - 0.0
-  - 50.0
-- path: trade.smart_exit_adx_exhaustion_lt
+  - 1.0
+- path: indicators.rsi_window
+  values:
+  - 10.0
+  - 14.0
+  - 16.0
+  - 20.0
+- path: thresholds.entry.ave_enabled
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.slow_drift_min_adx
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: thresholds.tp_and_momentum.rsi_short_weak
+  values:
+  - 30.8
+  - 44.0
+  - 57.2
+- path: trade.exit_cooldown_s
+  values:
+  - 10.0
+  - 15.0
+  - 20.0
+- path: trade.reef_short_rsi_block_lt
+  values:
+  - 21.0
+  - 30.0
+  - 39.0
+- path: trade.smart_exit_adx_exhaustion_lt_low_conf
   values:
   - 0.0
   - 15.0
   - 30.0
+- path: trade.tsme_require_adx_slope_negative
+  values:
+  - 0.0
+  - 1.0

--- a/backtester/sweeps/full_144v_17phase/p08_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p08_144v.yaml
@@ -4,38 +4,46 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: indicators.rsi_window
+- path: filters.adx_rising_saturation
   values:
+  - 28.0
+  - 40.0
+  - 52.0
+- path: market_regime.breadth_block_long_below
+  values:
+  - 7.0
   - 10.0
-  - 16.0
-  - 20.0
+  - 13.0
 - path: thresholds.entry.enable_pullback_entries
   values:
   - 0.0
   - 1.0
-- path: thresholds.stoch_rsi.block_long_if_k_gt
+- path: thresholds.entry.slow_drift_min_slope_pct
   values:
-  - 0.595
-  - 1.105
-- path: thresholds.tp_and_momentum.tp_mult_weak
+  - 0.00042
+  - 0.0006
+  - 0.00078
+- path: thresholds.tp_and_momentum.tp_mult_strong
   values:
-  - 2.1
+  - 4.9
+  - 7.0
+  - 9.1
+- path: trade.glitch_atr_mult
+  values:
+  - 8.4
+  - 12.0
+  - 15.6
+- path: trade.reef_short_rsi_extreme_lt
+  values:
+  - 17.5
+  - 25.0
+  - 32.5
+- path: trade.tp_atr_mult
+  values:
   - 3.0
-  - 3.9
-- path: trade.enable_breakeven_stop
+  - 5.5
+  - 8.0
+- path: trade.use_bbo_for_fills
   values:
   - 0.0
   - 1.0
-- path: trade.max_open_positions
-  values:
-  - 14.0
-  - 26.0
-- path: trade.slippage_bps
-  values:
-  - 7.0
-  - 13.0
-- path: trade.smart_exit_adx_exhaustion_lt_low_conf
-  values:
-  - 0.0
-  - 15.0
-  - 30.0

--- a/backtester/sweeps/full_144v_17phase/p09_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p09_144v.yaml
@@ -4,38 +4,42 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: indicators.stoch_rsi_smooth1
+- path: indicators.ave_avg_atr_window
   values:
-  - 2.0
-  - 4.0
-  - 5.0
+  - 35.0
+  - 50.0
+  - 65.0
+- path: market_regime.breadth_block_short_above
+  values:
+  - 63.0
+  - 90.0
+  - 100.0
 - path: thresholds.entry.enable_slow_drift_entries
   values:
   - 0.0
   - 1.0
-- path: thresholds.stoch_rsi.block_short_if_k_lt
+- path: thresholds.entry.slow_drift_rsi_long_min
   values:
-  - 0.105
-  - 0.195
-- path: trade.add_fraction_of_base_margin
+  - 35.0
+  - 50.0
+  - 65.0
+- path: thresholds.tp_and_momentum.tp_mult_weak
   values:
-  - 0.25
-  - 0.75
-  - 1.0
-- path: trade.enable_dynamic_leverage
-  values:
-  - 0.0
-  - 1.0
-- path: trade.max_total_margin_pct
-  values:
-  - 0.42
-  - 0.78
-- path: trade.tp_atr_mult
-  values:
+  - 2.1
   - 3.0
-  - 5.5
-  - 8.0
+  - 3.9
+- path: trade.glitch_price_dev_pct
+  values:
+  - 0.28
+  - 0.4
+  - 0.52
+- path: trade.reentry_cooldown_max_mins
+  values:
+  - 126.0
+  - 180.0
+  - 234.0
 - path: trade.tp_partial_min_notional_usd
   values:
   - 7.0
+  - 10.0
   - 13.0

--- a/backtester/sweeps/full_144v_17phase/p10_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p10_144v.yaml
@@ -4,38 +4,42 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: indicators.stoch_rsi_smooth2
+- path: indicators.ema_macro_window
   values:
-  - 2.0
-  - 4.0
+  - 140.0
+  - 200.0
+  - 260.0
+- path: thresholds.anomaly.ema_fast_dev_pct_gt
+  values:
+  - 0.35
+  - 0.5
+  - 0.65
+- path: thresholds.entry.pullback_require_macd_sign
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.slow_drift_rsi_short_max
+  values:
+  - 35.0
+  - 50.0
+  - 65.0
+- path: trade.add_cooldown_minutes
+  values:
+  - 42.0
+  - 60.0
+  - 78.0
+- path: trade.leverage
+  values:
+  - 1.0
+  - 3.0
   - 5.0
-- path: thresholds.entry.high_conf_volume_mult
+- path: trade.reentry_cooldown_min_mins
   values:
-  - 1.75
-  - 3.25
-- path: thresholds.tp_and_momentum.adx_strong_gt
-  values:
-  - 28.0
-  - 52.0
-- path: trade.add_min_confidence
-  values:
-  - 0.0
-  - 1.0
-  - 2.0
-- path: trade.enable_dynamic_sizing
-  values:
-  - 0.0
-  - 1.0
-- path: trade.min_notional_usd
-  values:
-  - 7.0
-  - 13.0
+  - 30.0
+  - 60.0
+  - 90.0
 - path: trade.tp_partial_pct
   values:
   - 0.35
+  - 0.5
   - 0.65
-- path: trade.trailing_distance_atr
-  values:
-  - 0.3
-  - 0.8
-  - 1.2

--- a/backtester/sweeps/full_144v_17phase/p11_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p11_144v.yaml
@@ -4,38 +4,42 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: indicators.stoch_rsi_window
+- path: indicators.stoch_rsi_smooth1
+  values:
+  - 2.0
+  - 4.0
+  - 5.0
+- path: thresholds.anomaly.price_change_pct_gt
+  values:
+  - 0.07
+  - 0.1
+  - 0.13
+- path: thresholds.entry.slow_drift_require_macd_sign
+  values:
+  - 0.0
+  - 1.0
+- path: thresholds.entry.slow_drift_slope_window
   values:
   - 10.0
-  - 16.0
-  - 20.0
-- path: thresholds.entry.pullback_min_adx
+  - 25.0
+  - 40.0
+- path: trade.add_fraction_of_base_margin
   values:
-  - 15.4
-  - 28.6
-- path: thresholds.tp_and_momentum.adx_weak_lt
+  - 0.25
+  - 0.75
+  - 1.0
+- path: trade.leverage_high
   values:
-  - 21.0
-  - 39.0
-- path: trade.allocation_pct
+  - 3.5
+  - 5.0
+  - 6.5
+- path: trade.reentry_cooldown_minutes
   values:
-  - 0.05
-  - 0.2
+  - 42.0
+  - 60.0
+  - 78.0
+- path: trade.trailing_distance_atr
+  values:
   - 0.3
-- path: trade.enable_partial_tp
-  values:
-  - 0.0
-  - 1.0
-- path: trade.reef_adx_threshold
-  values:
-  - 31.5
-  - 58.5
-- path: trade.trailing_distance_atr_low_conf
-  values:
-  - 0.0
-  - 1.0
-- path: trade.trailing_start_atr
-  values:
-  - 0.5
-  - 1.25
-  - 2.0
+  - 0.7
+  - 1.2

--- a/backtester/sweeps/full_144v_17phase/p12_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p12_144v.yaml
@@ -4,41 +4,42 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: filters.adx_rising_saturation
+- path: indicators.stoch_rsi_smooth2
   values:
-  - 28.0
-  - 52.0
-- path: filters.require_macro_alignment
+  - 2.0
+  - 4.0
+  - 5.0
+- path: thresholds.entry.ave_adx_mult
+  values:
+  - 0.875
+  - 1.25
+  - 1.625
+- path: thresholds.ranging.adx_below
+  values:
+  - 14.7
+  - 21.0
+  - 27.3
+- path: trade.add_min_confidence
   values:
   - 0.0
   - 1.0
-- path: indicators.vol_sma_window
-  values:
-  - 10.0
-  - 20.0
-  - 30.0
-- path: thresholds.entry.pullback_require_macd_sign
+  - 2.0
+- path: trade.block_exits_on_extreme_dev
   values:
   - 0.0
   - 1.0
-- path: thresholds.tp_and_momentum.rsi_long_strong
+- path: trade.leverage_low
   values:
-  - 36.4
-  - 67.6
-- path: trade.breakeven_start_atr
-  values:
-  - 0.3
   - 0.7
   - 1.0
-- path: trade.enable_pyramiding
+  - 1.3
+- path: trade.rsi_exit_lb_hi_profit
+  values:
+  - 21.0
+  - 30.0
+  - 39.0
+- path: trade.trailing_distance_atr_low_conf
   values:
   - 0.0
-  - 1.0
-- path: trade.reef_long_rsi_block_gt
-  values:
-  - 49.0
-  - 91.0
-- path: trade.trailing_start_atr_low_conf
-  values:
-  - 0.0
+  - 0.5
   - 1.0

--- a/backtester/sweeps/full_144v_17phase/p13_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p13_144v.yaml
@@ -4,41 +4,42 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: filters.enable_anomaly_filter
+- path: indicators.stoch_rsi_window
   values:
-  - 0.0
-  - 1.0
-- path: filters.require_volume_confirmation
-  values:
-  - 0.0
-  - 1.0
-- path: indicators.vol_trend_window
-  values:
-  - 3.0
-  - 7.0
   - 10.0
-- path: thresholds.entry.pullback_rsi_long_min
+  - 14.0
+  - 20.0
+- path: thresholds.entry.ave_atr_ratio_gt
   values:
-  - 35.0
-  - 65.0
-- path: thresholds.tp_and_momentum.rsi_long_weak
+  - 1.05
+  - 1.5
+  - 1.95
+- path: thresholds.ranging.bb_width_ratio_below
   values:
-  - 39.2
-  - 72.8
-- path: trade.confidence_mult_medium
+  - 0.56
+  - 0.8
+  - 1.04
+- path: trade.add_min_profit_atr
   values:
-  - 0.3
-  - 0.7
-  - 1.0
-- path: trade.enable_reef_filter
+  - 0.35
+  - 0.5
+  - 0.65
+- path: trade.bump_to_min_notional
   values:
   - 0.0
   - 1.0
-- path: trade.reef_long_rsi_extreme_gt
+- path: trade.leverage_max_cap
   values:
-  - 52.5
-  - 97.5
-- path: trade.tsme_min_profit_atr
+  - 0.0
+  - 0.5
+  - 1.0
+- path: trade.rsi_exit_lb_hi_profit_low_conf
   values:
-  - 0.7
-  - 1.3
+  - 0.0
+  - 30.0
+  - 50.0
+- path: trade.trailing_start_atr
+  values:
+  - 0.5
+  - 1.25
+  - 2.0

--- a/backtester/sweeps/full_144v_17phase/p14_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p14_144v.yaml
@@ -4,41 +4,42 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: filters.enable_extension_filter
+- path: indicators.vol_sma_window
   values:
-  - 0.0
-  - 1.0
-- path: filters.use_stoch_rsi_filter
+  - 10.0
+  - 20.0
+  - 30.0
+- path: thresholds.entry.ave_avg_atr_window
   values:
-  - 0.0
-  - 1.0
-- path: market_regime.auto_reverse_breadth_high
+  - 30.0
+  - 50.0
+  - 80.0
+- path: thresholds.ranging.min_signals
   values:
-  - 63.0
-  - 90.0
-  - 100.0
-- path: thresholds.entry.pullback_rsi_short_max
-  values:
-  - 35.0
-  - 65.0
-- path: thresholds.tp_and_momentum.rsi_short_strong
-  values:
-  - 33.6
-  - 62.4
-- path: trade.enable_rsi_overextension_exit
-  values:
-  - 0.0
-  - 1.0
-- path: trade.entry_min_confidence
-  values:
-  - 0.0
   - 1.0
   - 2.0
-- path: trade.reef_short_rsi_block_lt
+  - 3.0
+- path: trade.adx_sizing_full_adx
   values:
-  - 21.0
-  - 39.0
-- path: trade.tsme_require_adx_slope_negative
+  - 28.0
+  - 40.0
+  - 52.0
+- path: trade.enable_breakeven_stop
   values:
   - 0.0
+  - 1.0
+- path: trade.leverage_medium
+  values:
+  - 2.0
+  - 4.0
+  - 5.0
+- path: trade.rsi_exit_lb_lo_profit
+  values:
+  - 14.0
+  - 20.0
+  - 26.0
+- path: trade.trailing_start_atr_low_conf
+  values:
+  - 0.0
+  - 0.5
   - 1.0

--- a/backtester/sweeps/full_144v_17phase/p15_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p15_144v.yaml
@@ -4,41 +4,42 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: filters.enable_ranging_filter
+- path: indicators.vol_trend_window
   values:
-  - 0.0
-  - 1.0
-- path: filters.vol_confirm_include_prev
-  values:
-  - 0.0
-  - 1.0
-- path: market_regime.auto_reverse_breadth_low
-  values:
+  - 3.0
   - 7.0
   - 10.0
-  - 13.0
-- path: thresholds.entry.slow_drift_min_adx
+- path: thresholds.entry.btc_adx_override
   values:
-  - 7.0
-  - 13.0
-- path: thresholds.tp_and_momentum.rsi_short_weak
+  - 28.0
+  - 40.0
+  - 52.0
+- path: thresholds.ranging.rsi_high
   values:
-  - 30.8
-  - 57.2
-- path: trade.enable_ssf_filter
+  - 37.1
+  - 53.0
+  - 68.9
+- path: trade.adx_sizing_min_mult
+  values:
+  - 0.42
+  - 0.6
+  - 0.78
+- path: trade.enable_dynamic_leverage
   values:
   - 0.0
   - 1.0
-- path: trade.leverage
+- path: trade.max_adds_per_symbol
   values:
-  - 1.0
+  - 0.0
+  - 2.0
   - 3.0
-  - 5.0
-- path: trade.reef_short_rsi_extreme_lt
-  values:
-  - 17.5
-  - 32.5
-- path: trade.use_bbo_for_fills
+- path: trade.rsi_exit_lb_lo_profit_low_conf
   values:
   - 0.0
+  - 30.0
+  - 50.0
+- path: trade.tsme_min_profit_atr
+  values:
+  - 0.7
   - 1.0
+  - 1.3

--- a/backtester/sweeps/full_144v_17phase/p16_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p16_144v.yaml
@@ -4,41 +4,42 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: filters.require_adx_rising
+- path: market_regime.auto_reverse_breadth_high
+  values:
+  - 63.0
+  - 90.0
+  - 100.0
+- path: thresholds.entry.high_conf_volume_mult
+  values:
+  - 1.75
+  - 2.5
+  - 3.25
+- path: thresholds.ranging.rsi_low
+  values:
+  - 32.9
+  - 47.0
+  - 61.1
+- path: trade.allocation_pct
+  values:
+  - 0.05
+  - 0.15
+  - 0.3
+- path: trade.enable_dynamic_sizing
   values:
   - 0.0
   - 1.0
-- path: indicators.ave_avg_atr_window
+- path: trade.max_entry_orders_per_loop
   values:
-  - 35.0
-  - 65.0
-- path: market_regime.breadth_block_long_below
-  values:
-  - 7.0
-  - 10.0
-  - 13.0
-- path: thresholds.entry.slow_drift_min_slope_pct
-  values:
-  - 0.00042
-  - 0.00078
-- path: trade.add_cooldown_minutes
-  values:
-  - 42.0
-  - 78.0
-- path: trade.enable_vol_buffered_trailing
-  values:
-  - 0.0
-  - 1.0
-- path: trade.leverage_medium
-  values:
-  - 2.0
   - 4.0
-  - 5.0
-- path: trade.reentry_cooldown_max_mins
+  - 6.0
+  - 8.0
+- path: trade.rsi_exit_profit_atr_switch
   values:
-  - 126.0
-  - 234.0
+  - 1.05
+  - 1.5
+  - 1.95
 - path: trade.vol_baseline_pct
   values:
   - 0.007
+  - 0.01
   - 0.013

--- a/backtester/sweeps/full_144v_17phase/p17_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p17_144v.yaml
@@ -4,41 +4,42 @@
 initial_balance: 10000.0
 lookback: 200
 axes:
-- path: filters.require_btc_alignment
+- path: market_regime.auto_reverse_breadth_low
+  values:
+  - 7.0
+  - 10.0
+  - 13.0
+- path: thresholds.entry.macd_hist_entry_mode
   values:
   - 0.0
   - 1.0
-- path: market_regime.breadth_block_short_above
+  - 2.0
+- path: thresholds.stoch_rsi.block_long_if_k_gt
   values:
-  - 63.0
-  - 90.0
-  - 100.0
-- path: market_regime.enable_auto_reverse
+  - 0.595
+  - 0.85
+  - 1.105
+- path: trade.breakeven_buffer_atr
+  values:
+  - 0.035
+  - 0.05
+  - 0.065
+- path: trade.enable_partial_tp
   values:
   - 0.0
   - 1.0
-- path: thresholds.entry.slow_drift_require_macd_sign
-  values:
-  - 0.0
-  - 1.0
-- path: trade.add_min_profit_atr
-  values:
-  - 0.35
-  - 0.65
-- path: trade.entry_cooldown_s
+- path: trade.max_open_positions
   values:
   - 14.0
+  - 20.0
   - 26.0
-- path: trade.max_adds_per_symbol
+- path: trade.rsi_exit_ub_hi_profit
   values:
-  - 0.0
-  - 2.0
-  - 3.0
-- path: trade.reentry_cooldown_minutes
-  values:
-  - 42.0
-  - 78.0
+  - 49.0
+  - 70.0
+  - 91.0
 - path: trade.vol_scalar_max
   values:
   - 0.7
+  - 1.0
   - 1.3

--- a/backtester/sweeps/run_17phase_144v.sh
+++ b/backtester/sweeps/run_17phase_144v.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 # 17-phase 144v sweep runner (grid).
 #
-# Default scale:
+# Default scale (from manifest):
 # - 17 phases
-# - 17,280 combos per interval
+# - ~100k combos per interval (targeted)
 # - Intervals: 3m, 5m, 15m, 30m
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."


### PR DESCRIPTION
## Summary
- tune the 17-phase 144v pack from the prior ~17k scale to a practical ~100k CPU grid target
- upgrade `generate_17phase_144v.py` with target-based auto-tuning (`--target-combo`, default `100000`)
- keep full 143-axis coverage while promoting selected axes from 2-point to 3-point/4-point samples
- regenerate all 17 phase specs + manifest + README to reflect the new default scale

## Resulting scale
- phases: 17
- axes covered: 143 (full `full_144v` coverage)
- target combo: 100,000
- achieved combo: 100,602 per interval

## Validation
- `python3 -m py_compile backtester/sweeps/generate_17phase_144v.py`
- `bash -n backtester/sweeps/run_17phase_144v.sh`
- manifest integrity check: 143/143 path coverage and combo sum matches `manifest.total_combo`
