### PR TITLE
AQC-169 enforce GPU parity gate for runtime changes

### DIFF
--- a/.github/workflows/gpu-parity-gate.yml
+++ b/.github/workflows/gpu-parity-gate.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   gpu-parity-gate:
-    name: gpu-parity-gate
+    name: gpu-parity-gate (warning unless strict)
     runs-on: ${{ vars.AQC_GPU_PARITY_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -39,6 +39,8 @@ jobs:
 
       - name: Run GPU parity gate
         if: steps.changes.outputs.gpu_runtime == 'true'
+        env:
+          AQC_GPU_PARITY_STRICT: ${{ vars.AQC_GPU_PARITY_STRICT || '0' }}
         run: ./scripts/ci_gpu_parity_gate.sh
 
       - name: Skip when GPU runtime is unchanged

--- a/backtester/crates/bt-gpu/tests/gpu_runtime_parity_tiny_fixture.rs
+++ b/backtester/crates/bt-gpu/tests/gpu_runtime_parity_tiny_fixture.rs
@@ -7,6 +7,7 @@
 //! - On CUDA-capable machines: the test must pass.
 //! - On machines without CUDA runtime/device: the test prints a skip message
 //!   and returns without failing.
+//! - On CUDA misconfiguration: the test fails loudly.
 
 use std::any::Any;
 use std::collections::BTreeMap;
@@ -61,16 +62,7 @@ fn panic_payload_to_string(payload: Box<dyn Any + Send>) -> String {
 }
 
 fn is_cuda_unavailable_error(err: &DriverError) -> bool {
-    matches!(
-        err.0,
-        CUresult::CUDA_ERROR_NO_DEVICE
-            | CUresult::CUDA_ERROR_INVALID_DEVICE
-            | CUresult::CUDA_ERROR_NOT_INITIALIZED
-            | CUresult::CUDA_ERROR_DEINITIALIZED
-            | CUresult::CUDA_ERROR_SYSTEM_NOT_READY
-            | CUresult::CUDA_ERROR_SYSTEM_DRIVER_MISMATCH
-            | CUresult::CUDA_ERROR_STUB_LIBRARY
-    )
+    matches!(err.0, CUresult::CUDA_ERROR_NO_DEVICE | CUresult::CUDA_ERROR_INVALID_DEVICE)
 }
 
 fn probe_cuda_runtime() -> CudaProbe {

--- a/backtester/testdata/gpu_cpu_parity/README.md
+++ b/backtester/testdata/gpu_cpu_parity/README.md
@@ -49,5 +49,7 @@ cargo test -p bt-gpu --test gpu_runtime_parity_tiny_fixture -- --nocapture
 
 ## CI gate
 - `scripts/ci_gpu_parity_gate.sh` is the command-level parity gate used in CI.
-- It skips cleanly only when CUDA toolkit/runtime is unavailable.
+- It runs the tiny GPU fixture and emits an explicit warning when CUDA is unavailable.
+- By default (`AQC_GPU_PARITY_STRICT=0`), CUDA-unavailable runners continue with warning-only semantics.
+- Set `AQC_GPU_PARITY_STRICT=1` to fail fast when CUDA is unavailable.
 - Workflow: `.github/workflows/gpu-parity-gate.yml`.

--- a/scripts/ci_gpu_parity_gate.sh
+++ b/scripts/ci_gpu_parity_gate.sh
@@ -2,11 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-
-if ! command -v nvcc >/dev/null 2>&1; then
-    echo "[gpu-parity-gate] SKIP: CUDA toolkit unavailable (nvcc not found)."
-    exit 0
-fi
+STRICT_MODE="${AQC_GPU_PARITY_STRICT:-0}"
 
 # On WSL2, libcuda is often exposed via this path.
 if [[ -d /usr/lib/wsl/lib ]]; then
@@ -14,5 +10,28 @@ if [[ -d /usr/lib/wsl/lib ]]; then
 fi
 
 cd "${ROOT_DIR}/backtester"
-echo "[gpu-parity-gate] Running tiny GPU runtime parity fixture..."
-cargo test -p bt-gpu --test gpu_runtime_parity_tiny_fixture -- --nocapture
+echo "[gpu-parity-gate] Running tiny GPU runtime parity fixture (strict=${STRICT_MODE})..."
+
+LOG_FILE="$(mktemp)"
+trap 'rm -f "${LOG_FILE}"' EXIT
+
+if ! cargo test -p bt-gpu --test gpu_runtime_parity_tiny_fixture -- --nocapture 2>&1 | tee "${LOG_FILE}"; then
+    echo "[gpu-parity-gate] FAIL: tiny GPU runtime parity fixture failed."
+    exit 1
+fi
+
+if grep -Fq "[gpu-parity] SKIP: CUDA unavailable" "${LOG_FILE}"; then
+    echo "::warning::[gpu-parity-gate] CUDA unavailable on this runner; GPU parity assertions were not enforced."
+    case "${STRICT_MODE}" in
+        1 | true | TRUE | yes | YES | on | ON)
+            echo "[gpu-parity-gate] STRICT MODE: AQC_GPU_PARITY_STRICT=${STRICT_MODE}; failing because CUDA is unavailable."
+            exit 1
+            ;;
+        *)
+            echo "[gpu-parity-gate] Non-strict mode: continuing with warning only."
+            ;;
+    esac
+    exit 0
+fi
+
+echo "[gpu-parity-gate] PASS: GPU parity assertions executed."


### PR DESCRIPTION
## Summary
- add a tiny `bt-gpu` runtime parity fixture test that compares GPU sweep output against committed expected fixture output
- tighten CUDA skip classification so only true CUDA unavailability skips; CUDA misconfiguration now fails loudly
- update the parity gate script/workflow to emit explicit warnings when CUDA is unavailable, with optional strict mode via `AQC_GPU_PARITY_STRICT=1`
- document strict vs non-strict gate semantics in the parity fixture README
- code-only follow-up: no branch protection or repository settings changes

## Validation
- `cd backtester && cargo test -p bt-core --test gpu_cpu_parity`
- `./scripts/ci_gpu_parity_gate.sh`
- `AQC_GPU_PARITY_STRICT=1 ./scripts/ci_gpu_parity_gate.sh` (expected failure on runners without CUDA)

Refs #169
