### PR TITLE
TKT-194: Harden Rust-Python kernel binding

### DIFF
--- a/backtester/Cargo.lock
+++ b/backtester/Cargo.lock
@@ -128,6 +128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bt-runtime"
+version = "0.1.0"
+dependencies = [
+ "bt-core",
+ "pyo3",
+ "serde_json",
+]
+
+[[package]]
 name = "bt-signals"
 version = "0.1.0"
 dependencies = [
@@ -347,6 +356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +430,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "nalgebra"
@@ -481,6 +508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +562,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -623,6 +725,12 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -752,6 +860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +909,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/backtester/Cargo.toml
+++ b/backtester/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/bt-cli",
     "crates/bt-gpu",
     "crates/risk-core",
+    "crates/bt-runtime",
 ]
 
 [workspace.dependencies]

--- a/backtester/crates/bt-runtime/Cargo.toml
+++ b/backtester/crates/bt-runtime/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bt-runtime"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "bt_runtime"
+crate-type = ["cdylib"]
+
+[dependencies]
+bt-core = { path = "../bt-core" }
+pyo3 = { version = "0.22", features = ["extension-module"] }
+serde_json = { workspace = true }

--- a/backtester/crates/bt-runtime/src/lib.rs
+++ b/backtester/crates/bt-runtime/src/lib.rs
@@ -1,0 +1,242 @@
+//! Python binding entrypoint for the Rust decision kernel.
+//!
+//! The module exposes a small JSON envelope API so Python callers can execute the
+//! canonical `decision_kernel::step` transition without mirroring Rust structs.
+//! The response is always JSON, which keeps the interface language-agnostic and
+//! easy to persist in test artefacts.
+
+use pyo3::prelude::*;
+use serde::Serialize;
+use serde_json::{self, Value, json};
+
+use bt_core::decision_kernel;
+
+const ERROR_OK_PREFIX: &str = "bt-runtime:";
+
+#[derive(Serialize)]
+struct ErrorObject {
+    code: String,
+    message: String,
+    details: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ErrorEnvelope {
+    ok: bool,
+    error: ErrorObject,
+}
+
+#[derive(Serialize)]
+struct StepEnvelope {
+    ok: bool,
+    decision: decision_kernel::DecisionResult,
+}
+
+fn validation_error(code: &str, message: &str, details: Vec<String>) -> String {
+    serde_json::to_string(&ErrorEnvelope {
+        ok: false,
+        error: ErrorObject {
+            code: code.to_string(),
+            message: message.to_string(),
+            details,
+        },
+    })
+    .unwrap_or_else(|_| {
+        json!({
+            "ok": false,
+            "error": {
+                "code": code,
+                "message": message,
+                "details": details,
+            }
+        })
+        .to_string()
+    })
+}
+
+fn as_u32(payload: &str, label: &str) -> PyResult<u32> {
+    let payload: Value = serde_json::from_str(payload).map_err(|err| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "{ERROR_OK_PREFIX} cannot parse {label} JSON payload: {err}"
+        ))
+    })?;
+    payload
+        .as_object()
+        .and_then(|obj| obj.get("schema_version"))
+        .and_then(|value| value.as_u64())
+        .map(|v| v as u32)
+        .ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "{ERROR_OK_PREFIX} missing schema_version in {label}"
+            ))
+        })
+}
+
+fn ensure_matching_schema_version(
+    state_version: u32,
+    event_version: u32,
+    params_version: u32,
+    expected_version: u32,
+) -> Option<Vec<String>> {
+    if state_version == expected_version
+        && event_version == expected_version
+        && params_version == expected_version
+    {
+        return None;
+    }
+
+    let mut errors = Vec::with_capacity(3);
+    if state_version != expected_version {
+        errors.push(format!("state schema_version={state_version}, expected={expected_version}"));
+    }
+    if event_version != expected_version {
+        errors.push(format!("event schema_version={event_version}, expected={expected_version}"));
+    }
+    if params_version != expected_version {
+        errors.push(format!(
+            "params schema_version={params_version}, expected={expected_version}"
+        ));
+    }
+    Some(errors)
+}
+
+fn default_schema_version() -> u32 {
+    decision_kernel::StrategyState::new(0.0, 0).schema_version
+}
+
+fn step_envelope(decision: decision_kernel::DecisionResult) -> String {
+    serde_json::to_string(&StepEnvelope { ok: true, decision }).unwrap_or_else(|err| {
+        validation_error(
+            "SERIALIZATION_FAILED",
+            "Failed to serialise kernel decision envelope",
+            vec![err.to_string()],
+        )
+    })
+}
+
+#[pyfunction]
+fn step_decision(state_json: &str, event_json: &str, params_json: &str) -> PyResult<String> {
+    let state_version = match as_u32(state_json, "state") {
+        Ok(v) => v,
+        Err(err) => {
+            return Ok(validation_error(
+                "INVALID_JSON",
+                "Failed to parse state payload",
+                vec![err.to_string()],
+            ));
+        }
+    };
+
+    let event_version = match as_u32(event_json, "event") {
+        Ok(v) => v,
+        Err(err) => {
+            return Ok(validation_error(
+                "INVALID_JSON",
+                "Failed to parse event payload",
+                vec![err.to_string()],
+            ));
+        }
+    };
+
+    let params_version = match as_u32(params_json, "params") {
+        Ok(v) => v,
+        Err(err) => {
+            return Ok(validation_error(
+                "INVALID_JSON",
+                "Failed to parse params payload",
+                vec![err.to_string()],
+            ));
+        }
+    };
+
+    let expected = default_schema_version();
+    if let Some(details) = ensure_matching_schema_version(state_version, event_version, params_version, expected)
+    {
+        return Ok(validation_error(
+            "SCHEMA_VERSION_MISMATCH",
+            "Schema version mismatch",
+            details,
+        ));
+    }
+
+    let state_result = serde_json::from_str::<decision_kernel::StrategyState>(state_json);
+    let state = match state_result {
+        Ok(value) => value,
+        Err(err) => {
+            return Ok(validation_error(
+                "INVALID_JSON",
+                "Failed to parse StrategyState",
+                vec![err.to_string()],
+            ));
+        }
+    };
+
+    let event_result = serde_json::from_str::<decision_kernel::MarketEvent>(event_json);
+    let event = match event_result {
+        Ok(value) => value,
+        Err(err) => {
+            return Ok(validation_error(
+                "INVALID_JSON",
+                "Failed to parse MarketEvent",
+                vec![err.to_string()],
+            ));
+        }
+    };
+
+    let params_result = serde_json::from_str::<decision_kernel::KernelParams>(params_json);
+    let params = match params_result {
+        Ok(value) => value,
+        Err(err) => {
+            return Ok(validation_error(
+                "INVALID_JSON",
+                "Failed to parse KernelParams",
+                vec![err.to_string()],
+            ));
+        }
+    };
+
+    let decision = decision_kernel::step(&state, &event, &params);
+    if !decision.diagnostics.errors.is_empty() {
+        return Ok(validation_error(
+            "KERNEL_DECISION_REJECTED",
+            "Kernel diagnostics reported errors",
+            decision.diagnostics.errors.clone(),
+        ));
+    }
+
+    Ok(step_envelope(decision))
+}
+
+#[pyfunction]
+fn default_kernel_state_json(initial_cash_usd: f64, timestamp_ms: i64) -> PyResult<String> {
+    let state = decision_kernel::StrategyState::new(initial_cash_usd, timestamp_ms);
+    serde_json::to_string(&state).map_err(|err| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "failed to serialise default state: {err}"
+        ))
+    })
+}
+
+#[pyfunction]
+fn default_kernel_params_json() -> PyResult<String> {
+    let params = decision_kernel::KernelParams::default();
+    serde_json::to_string(&params).map_err(|err| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "failed to serialise default params: {err}"
+        ))
+    })
+}
+
+#[pyfunction]
+fn schema_version(payload_json: &str) -> PyResult<u32> {
+    as_u32(payload_json, "payload")
+}
+
+#[pymodule]
+fn bt_runtime(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(step_decision, m)?)?;
+    m.add_function(wrap_pyfunction!(default_kernel_state_json, m)?)?;
+    m.add_function(wrap_pyfunction!(default_kernel_params_json, m)?)?;
+    m.add_function(wrap_pyfunction!(schema_version, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
Implements TKT-194 hardening for kernel binding and provider path.

- Adds bt-runtime crate as dedicated PyO3 extension.
- Adds Rust→Python binding functions: step_decision/default state/params/schema_version.
- Adds kernel decision provider in engine/core.py using bt_runtime.
- Fixes now_ms shadow bug in kernel provider.
- Adds tests for provider path and schema-mismatch/invalid-json error codes.

Acceptance checklist:
- [x] Wrapper test calling Rust from Python (via optional import + schema checks)
- [x] Invalid schema returns explicit error code
- [x] Invalid JSON returns explicit error code
- [ ] Bench harness proves low-overhead envelope
- [ ] No Python strategy code path makes decisions (covered by existing TKT-195+ and runtime provider wiring)