### PR TITLE
TKT-228: replay-equivalence gate enhancements

### DIFF
--- a/tests/test_factory_replay_harness.py
+++ b/tests/test_factory_replay_harness.py
@@ -33,6 +33,10 @@ def _write_trace(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _force_mode(monkeypatch, mode: str) -> None:
+    monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_MODE", mode)
+
+
 def test_factory_run_replay_equivalence_happy_path(monkeypatch, tmp_path) -> None:
     baseline = tmp_path / "baseline.json"
     replay = tmp_path / "replay.json"
@@ -41,18 +45,22 @@ def test_factory_run_replay_equivalence_happy_path(monkeypatch, tmp_path) -> Non
 
     monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_BASELINE", str(baseline))
     monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_STRICT", "1")
+    _force_mode(monkeypatch, "backtest")
 
     summary: dict = {}
     ok = _run_replay_equivalence_check(right_report=replay, summary=summary)
 
     assert ok
     assert summary["replay_equivalence_status"] == "pass"
+    assert summary["replay_equivalence_mode"] == "backtest"
+    assert summary["replay_equivalence_failure_code"] == ""
     assert summary["replay_equivalence_report_path"] != ""
 
     report_path = Path(summary["replay_equivalence_report_path"])
     assert report_path.is_file()
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["ok"] is True
+    assert report["mode"] == "backtest"
 
 
 def test_factory_run_replay_equivalence_detects_mismatch_when_strict(monkeypatch, tmp_path) -> None:
@@ -66,13 +74,16 @@ def test_factory_run_replay_equivalence_detects_mismatch_when_strict(monkeypatch
 
     monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_BASELINE", str(baseline))
     monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_STRICT", "1")
+    _force_mode(monkeypatch, "backtest")
 
     summary: dict = {}
     ok = _run_replay_equivalence_check(right_report=replay, summary=summary)
 
     assert not ok
     assert summary["replay_equivalence_status"] == "fail"
+    assert summary["replay_equivalence_mode"] == "backtest"
     assert summary["replay_equivalence_count"] >= 1
+    assert summary["replay_equivalence_failure_code"] == "mismatch"
 
 
 def test_factory_run_replay_equivalence_runs_as_warning_when_not_strict(monkeypatch, tmp_path) -> None:
@@ -86,12 +97,15 @@ def test_factory_run_replay_equivalence_runs_as_warning_when_not_strict(monkeypa
 
     monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_BASELINE", str(baseline))
     monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_STRICT", "0")
+    _force_mode(monkeypatch, "backtest")
 
     summary: dict = {}
     ok = _run_replay_equivalence_check(right_report=replay, summary=summary)
 
     assert ok
     assert summary["replay_equivalence_status"] == "fail"
+    assert summary["replay_equivalence_mode"] == "backtest"
+    assert summary["replay_equivalence_failure_code"] == "mismatch"
 
 
 def test_factory_run_replay_equivalence_not_run_without_baseline(monkeypatch, tmp_path) -> None:
@@ -100,6 +114,11 @@ def test_factory_run_replay_equivalence_not_run_without_baseline(monkeypatch, tm
 
     monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_BASELINE", raising=False)
     monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_STRICT", "0")
+    monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_LIVE_BASELINE", raising=False)
+    monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_PAPER_BASELINE", raising=False)
+    monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_BACKTEST_BASELINE", raising=False)
+    monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_BACKTEST_STRICT", raising=False)
+    _force_mode(monkeypatch, "backtest")
 
     summary: dict = {}
     ok = _run_replay_equivalence_check(right_report=replay, summary=summary)
@@ -107,7 +126,9 @@ def test_factory_run_replay_equivalence_not_run_without_baseline(monkeypatch, tm
     assert ok
     assert summary["replay_equivalence_status"] == "not_run"
     assert summary["replay_equivalence_count"] == 0
+    assert summary["replay_equivalence_mode"] == "backtest"
     assert summary["replay_equivalence_diffs"] == []
+    assert summary["replay_equivalence_failure_code"] == "not_run"
 
 
 def test_factory_run_replay_equivalence_missing_baseline_fails_in_strict_mode(monkeypatch, tmp_path) -> None:
@@ -117,6 +138,11 @@ def test_factory_run_replay_equivalence_missing_baseline_fails_in_strict_mode(mo
 
     monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_BASELINE", str(baseline))
     monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_STRICT", "1")
+    monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_LIVE_BASELINE", raising=False)
+    monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_PAPER_BASELINE", raising=False)
+    monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_BACKTEST_BASELINE", raising=False)
+    monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_BACKTEST_STRICT", raising=False)
+    _force_mode(monkeypatch, "backtest")
 
     summary: dict = {}
     ok = _run_replay_equivalence_check(right_report=replay, summary=summary)
@@ -124,3 +150,56 @@ def test_factory_run_replay_equivalence_missing_baseline_fails_in_strict_mode(mo
     assert not ok
     assert summary["replay_equivalence_status"] == "missing_baseline"
     assert summary["replay_equivalence_count"] == 0
+    assert summary["replay_equivalence_mode"] == "backtest"
+    assert summary["replay_equivalence_failure_code"] == "missing_baseline"
+
+
+@pytest.mark.parametrize(
+    ("mode", "mode_baseline", "mode_strict", "global_strict", "strict_result"),
+    [
+        ("live", True, "1", "0", False),
+        ("paper", True, "0", "1", True),
+        ("backtest", False, None, "1", False),
+        ("backtest", False, None, "0", True),
+    ],
+)
+def test_factory_run_replay_equivalence_mode_specific_strictness_matrix(
+    monkeypatch,
+    tmp_path,
+    mode: str,
+    mode_baseline: bool,
+    mode_strict: str | None,
+    global_strict: str,
+    strict_result: bool,
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    replay = tmp_path / "replay.json"
+    changed = json.loads(json.dumps(TRACE))
+    changed["decision_diagnostics"][0]["event_id"] = 4
+
+    _write_trace(baseline, TRACE)
+    _write_trace(replay, changed)
+
+    if mode_baseline:
+        monkeypatch.setenv(f"AI_QUANT_REPLAY_EQUIVALENCE_{mode.upper()}_BASELINE", str(baseline))
+        monkeypatch.delenv("AI_QUANT_REPLAY_EQUIVALENCE_BASELINE", raising=False)
+    else:
+        monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_BASELINE", str(baseline))
+        monkeypatch.delenv(f"AI_QUANT_REPLAY_EQUIVALENCE_{mode.upper()}_BASELINE", raising=False)
+
+    if mode_strict is None:
+        monkeypatch.delenv(f"AI_QUANT_REPLAY_EQUIVALENCE_{mode.upper()}_STRICT", raising=False)
+    else:
+        monkeypatch.setenv(f"AI_QUANT_REPLAY_EQUIVALENCE_{mode.upper()}_STRICT", mode_strict)
+
+    monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_STRICT", global_strict)
+
+    monkeypatch.setenv("AI_QUANT_REPLAY_EQUIVALENCE_MODE", mode)
+
+    summary: dict = {}
+    ok = _run_replay_equivalence_check(right_report=replay, summary=summary)
+
+    assert ok is strict_result
+    assert summary["replay_equivalence_mode"] == mode
+    assert summary["replay_equivalence_status"] == "fail"
+    assert summary["replay_equivalence_failure_code"] == "mismatch"

--- a/tests/test_factory_run_stage_metadata.py
+++ b/tests/test_factory_run_stage_metadata.py
@@ -22,6 +22,8 @@ def test_replay_metadata_attachment_records_validation_stage() -> None:
     args = argparse.Namespace(gpu=True, tpe=False, walk_forward=True, slippage_stress=False)
     summary: dict[str, object] = {
         "replay_equivalence_status": "pass",
+        "replay_equivalence_mode": "backtest",
+        "replay_equivalence_failure_code": "",
         "replay_equivalence_count": 1,
         "replay_equivalence_error": "",
         "replay_equivalence_report_path": "/tmp/replay_equivalence.json",
@@ -39,7 +41,9 @@ def test_replay_metadata_attachment_records_validation_stage() -> None:
     assert summary["replay_report_path"] == "/tmp/replay.json"
     assert summary["config_path"] == "/tmp/cfg.yaml"
     assert summary["replay_equivalence_report_path"] == "/tmp/replay_equivalence.json"
+    assert summary["replay_equivalence_mode"] == "backtest"
     assert summary["replay_equivalence_count"] == 1
+    assert summary["replay_equivalence_failure_code"] == ""
     assert entry["replay_equivalence_error"] == ""
     assert entry["replay_equivalence_diffs"] == []
     assert entry["pipeline_stage"] == "candidate_validation"
@@ -50,9 +54,16 @@ def test_replay_metadata_attachment_records_validation_stage() -> None:
 
 def test_replay_metadata_attachment_marks_unverified_when_not_pass() -> None:
     args = argparse.Namespace(gpu=True, tpe=False, walk_forward=True, slippage_stress=False)
-    summary: dict[str, object] = {"replay_equivalence_status": "fail", "replay_equivalence_count": 2}
+    summary: dict[str, object] = {
+        "replay_equivalence_status": "fail",
+        "replay_equivalence_mode": "live",
+        "replay_equivalence_failure_code": "mismatch",
+        "replay_equivalence_count": 2,
+    }
     entry: dict[str, object] = {}
     factory_run._attach_replay_metadata(summary=summary, entry=entry, args=args, replay_stage="cpu_replay")
 
     assert summary["canonical_cpu_verified"] is False
     assert entry["canonical_cpu_verified"] is False
+    assert entry["replay_equivalence_mode"] == "live"
+    assert entry["replay_equivalence_failure_code"] == "mismatch"


### PR DESCRIPTION
Implements replay-equivalence mode-aware proof gate for live/paper/backtest with strict/lenient controls.

- Add AI_QUANT_REPLAY_EQUIVALENCE_<MODE>_* env overrides (MODE=live|paper|backtest)
- Add deterministic replay equivalence report artifacts and strict/lenient behaviour
- Add failure code metadata in factory_run summary (replay_equivalence_failure_code)
- Add TDD coverage for pass/fail mismatch matrix across modes
