### PR TITLE
feat: multi-paper monitor, balance sync, v8 runtime fixes

### DIFF
--- a/bt_runtime.so
+++ b/bt_runtime.so
@@ -1,0 +1,1 @@
+backtester/target/release/bt_runtime.so

--- a/engine/core.py
+++ b/engine/core.py
@@ -432,7 +432,8 @@ class KernelDecisionRustBindingProvider:
                 "Kernel state file corrupt, creating fresh: %s\n%s",
                 state_path, traceback.format_exc(),
             )
-        fresh = self._runtime.default_kernel_state_json(10_000.0, now_ms())
+        _seed = float(os.getenv("AI_QUANT_PAPER_BALANCE", "10000.0"))
+        fresh = self._runtime.default_kernel_state_json(_seed, now_ms())
         logger.info("Kernel state created fresh")
         self._persist_state(fresh)
         return fresh

--- a/monitor/server.py
+++ b/monitor/server.py
@@ -1020,8 +1020,22 @@ def mode_paths(mode: str) -> tuple[Path, Path]:
         db = Path(os.getenv("AIQ_MONITOR_LIVE_DB", str(AIQ_ROOT / "trading_engine_live.db")))
         log = Path(os.getenv("AIQ_MONITOR_LIVE_LOG", str(AIQ_ROOT / "live_daemon_log.txt")))
         return db, log
-    db = Path(os.getenv("AIQ_MONITOR_PAPER_DB", str(AIQ_ROOT / "trading_engine.db")))
-    log = Path(os.getenv("AIQ_MONITOR_PAPER_LOG", str(AIQ_ROOT / "daemon_log.txt")))
+    # paper1/2/3 support: "paper" is alias for "paper1"
+    if mode2 in ("paper", "paper1"):
+        db = Path(os.getenv("AIQ_MONITOR_PAPER1_DB", os.getenv("AIQ_MONITOR_PAPER_DB", str(AIQ_ROOT / "trading_engine.db"))))
+        log = Path(os.getenv("AIQ_MONITOR_PAPER1_LOG", os.getenv("AIQ_MONITOR_PAPER_LOG", str(AIQ_ROOT / "daemon_log.txt"))))
+        return db, log
+    if mode2 == "paper2":
+        db = Path(os.getenv("AIQ_MONITOR_PAPER2_DB", str(AIQ_ROOT / "trading_engine_paper2.db")))
+        log = Path(os.getenv("AIQ_MONITOR_PAPER2_LOG", str(AIQ_ROOT / "paper2_daemon_log.txt")))
+        return db, log
+    if mode2 == "paper3":
+        db = Path(os.getenv("AIQ_MONITOR_PAPER3_DB", str(AIQ_ROOT / "trading_engine_paper3.db")))
+        log = Path(os.getenv("AIQ_MONITOR_PAPER3_LOG", str(AIQ_ROOT / "paper3_daemon_log.txt")))
+        return db, log
+    # fallback: treat unknown as paper1
+    db = Path(os.getenv("AIQ_MONITOR_PAPER1_DB", os.getenv("AIQ_MONITOR_PAPER_DB", str(AIQ_ROOT / "trading_engine.db"))))
+    log = Path(os.getenv("AIQ_MONITOR_PAPER1_LOG", os.getenv("AIQ_MONITOR_PAPER_LOG", str(AIQ_ROOT / "daemon_log.txt"))))
     return db, log
 
 

--- a/monitor/static/app.js
+++ b/monitor/static/app.js
@@ -174,17 +174,24 @@
 
   /* ── Mode / prefs ── */
 
+  const MODE_BUTTONS = [
+    { id: "modeLive", mode: "live" },
+    { id: "modePaper1", mode: "paper1" },
+    { id: "modePaper2", mode: "paper2" },
+    { id: "modePaper3", mode: "paper3" },
+  ];
+
   function setSeg(mode) {
     state.mode = mode;
     state.midDecsBySym = {};
     state.lastMidBySym = {};
     state.midFlashTimers = {};
-    const live = $("#modeLive");
-    const paper = $("#modePaper");
-    live.classList.toggle("is-on", mode === "live");
-    paper.classList.toggle("is-on", mode === "paper");
-    live.setAttribute("aria-selected", mode === "live" ? "true" : "false");
-    paper.setAttribute("aria-selected", mode === "paper" ? "true" : "false");
+    for (const mb of MODE_BUTTONS) {
+      const el = $("#" + mb.id);
+      if (!el) continue;
+      el.classList.toggle("is-on", mode === mb.mode);
+      el.setAttribute("aria-selected", mode === mb.mode ? "true" : "false");
+    }
     if (isMobile()) {
       const mv = storageGet(prefKey("mobileView"));
       setMobileView(mv || "list", { persist: false });
@@ -1799,8 +1806,10 @@
   /* ── UI bindings ── */
 
   function bindUi() {
-    $("#modeLive").addEventListener("click", () => { state.focus = null; setSeg("live"); pollSnapshot(); });
-    $("#modePaper").addEventListener("click", () => { state.focus = null; setSeg("paper"); pollSnapshot(); });
+    for (const mb of MODE_BUTTONS) {
+      const el = $("#" + mb.id);
+      if (el) el.addEventListener("click", () => { state.focus = null; setSeg(mb.mode); pollSnapshot(); });
+    }
     const ml = $("#mnavList");
     const mf = $("#mnavFocus");
     if (ml) ml.addEventListener("click", () => setMobileView("list", { focusSearch: true }));

--- a/monitor/static/index.html
+++ b/monitor/static/index.html
@@ -29,7 +29,9 @@
 
         <div class="seg" role="tablist" aria-label="Mode">
           <button id="modeLive" class="segbtn" role="tab" aria-selected="true" data-mode="live">LIVE</button>
-          <button id="modePaper" class="segbtn" role="tab" aria-selected="false" data-mode="paper">PAPER</button>
+          <button id="modePaper1" class="segbtn" role="tab" aria-selected="false" data-mode="paper1">P1</button>
+          <button id="modePaper2" class="segbtn" role="tab" aria-selected="false" data-mode="paper2">P2</button>
+          <button id="modePaper3" class="segbtn" role="tab" aria-selected="false" data-mode="paper3">P3</button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- **Monitor multi-paper tabs**: Replace LIVE/PAPER with LIVE/P1/P2/P3, each backed by separate DB via `AIQ_MONITOR_PAPER{1,2,3}_DB` env vars
- **Paper balance sync from live**: On paper daemon startup (when `AI_QUANT_PAPER_BALANCE_FROM_LIVE=1`), fetch live Hyperliquid withdrawable balance and use as seed; writes seed record to trades table for monitor display
- **Fix missing bt_runtime.so**: Add symlink to project root (lost during v8 worktree migration) — was causing silent engine loop failures (no heartbeat, no trades)
- **Fix logging.basicConfig**: Logger output (including heartbeat) was silently dropped — now configured after sqlite_stdio_logger so output reaches both journalctl and DB
- **Fix KernelDecisionRustBindingProvider**: Use `AI_QUANT_PAPER_BALANCE` env var instead of hardcoded $10,000 for fresh kernel state

## Test plan
- [x] All 4 daemons (live + paper1/2/3) show `health.ok: true` with heartbeat in DB
- [x] Monitor tabs LIVE/P1/P2/P3 each show correct DB data
- [x] `curl /api/snapshot?mode=paper{1,2,3}` returns `realised_usd: 234.59` (live balance)
- [x] `kernel_equity` matches `realised_usd` — no drift warning
- [x] Paper balance sync logged on startup: `paper balance synced from live: $234.59`

🤖 Generated with [Claude Code](https://claude.com/claude-code)