### PR TITLE
feat: gated sweep axes + parameter cleanup

### DIFF
--- a/backtester/crates/bt-gpu/src/axis_split.rs
+++ b/backtester/crates/bt-gpu/src/axis_split.rs
@@ -75,14 +75,17 @@ mod tests {
             SweepAxis {
                 path: "trade.sl_atr_mult".to_string(),
                 values: vec![1.5, 2.0],
+                gate: None,
             },
             SweepAxis {
                 path: "indicators.ema_slow_window".to_string(),
                 values: vec![30.0, 50.0],
+                gate: None,
             },
             SweepAxis {
                 path: "trade.tp_atr_mult".to_string(),
                 values: vec![3.0, 5.0],
+                gate: None,
             },
         ];
         let (ind, trade) = split_axes(&axes);
@@ -97,10 +100,12 @@ mod tests {
             SweepAxis {
                 path: "a".to_string(),
                 values: vec![1.0, 2.0],
+                gate: None,
             },
             SweepAxis {
                 path: "b".to_string(),
                 values: vec![10.0, 20.0],
+                gate: None,
             },
         ];
         let combos = generate_combinations(&axes);

--- a/backtester/crates/bt-gpu/tests/tp_atr_mult_directional_parity.rs
+++ b/backtester/crates/bt-gpu/tests/tp_atr_mult_directional_parity.rs
@@ -142,6 +142,7 @@ fn run_gpu_pnl_by_axis(
         axes: vec![SweepAxis {
             path: "trade.tp_atr_mult".to_string(),
             values: TP_AXIS_VALUES.to_vec(),
+            gate: None,
         }],
         initial_balance: INITIAL_BALANCE,
         lookback: 0,

--- a/backtester/sweeps/full_144v.yaml
+++ b/backtester/sweeps/full_144v.yaml
@@ -1,4 +1,4 @@
-# sweep_full 142v profile (was 144v — see changelog below)
+# sweep_full 141v profile (was 144v → 142v → 141v — see changelog below)
 #
 # Scope:
 # - Expands sweep coverage from the legacy 34-axis profile to broad strategy coverage.
@@ -27,240 +27,269 @@
 #                 both wastes 3× compute). Added trade.tp_partial_atr_mult
 #                 (fully implemented in Rust+Python, has sweep match arm,
 #                 materially impacts trade behavior). Net: +1 −1 = 142 axes.
-initial_balance: 10000.0
+initial_balance: 10000000
 lookback: 200
 axes:
 - path: filters.adx_rising_saturation
+  gate:
+    path: filters.require_adx_rising
+    eq: 1
   values:
-  - 28.0
-  - 40.0
-  - 52.0
+  - 28
+  - 40
+  - 52
 - path: filters.enable_anomaly_filter
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: filters.enable_extension_filter
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: filters.enable_ranging_filter
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: filters.require_adx_rising
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: filters.require_btc_alignment
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: filters.require_macro_alignment
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: filters.require_volume_confirmation
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: filters.use_stoch_rsi_filter
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: filters.vol_confirm_include_prev
+  gate:
+    path: filters.require_volume_confirmation
+    eq: 1
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: indicators.adx_window
   values:
-  - 8.0
-  - 10.0
-  - 12.0
-  - 14.0
-  - 16.0
-  - 18.0
+  - 8
+  - 10
+  - 12
+  - 14
+  - 16
+  - 18
 - path: indicators.atr_window
   values:
-  - 10.0
-  - 12.0
-  - 14.0
-  - 16.0
-  - 18.0
-  - 20.0
+  - 10
+  - 12
+  - 14
+  - 16
+  - 18
+  - 20
 - path: indicators.bb_width_avg_window
   values:
-  - 15.0
-  - 20.0
-  - 25.0
-  - 30.0
-  - 35.0
-  - 40.0
-  - 45.0
-  - 50.0
+  - 20
+  - 30
+  - 40
+  - 50
 - path: indicators.bb_window
   values:
-  - 10.0
-  - 15.0
-  - 20.0
-  - 25.0
-  - 30.0
+  - 10
+  - 15
+  - 20
+  - 25
+  - 30
 - path: indicators.ema_fast_window
   values:
-  - 5.0
-  - 6.0
-  - 7.0
-  - 8.0
-  - 9.0
-  - 10.0
-  - 12.0
-  - 14.0
-  - 16.0
-  - 18.0
-  - 20.0
+  - 5
+  - 8
+  - 12
+  - 16
+  - 20
 - path: indicators.ema_macro_window
   values:
-  - 140.0
-  - 200.0
-  - 260.0
+  - 140
+  - 200
+  - 260
 - path: indicators.ema_slow_window
   values:
-  - 10.0
-  - 15.0
-  - 20.0
-  - 25.0
-  - 30.0
-  - 35.0
-  - 40.0
-  - 45.0
-  - 50.0
+  - 15
+  - 25
+  - 35
+  - 50
 - path: indicators.rsi_window
   values:
-  - 10.0
-  - 12.0
-  - 14.0
-  - 16.0
-  - 18.0
-  - 20.0
+  - 10
+  - 12
+  - 14
+  - 16
+  - 18
+  - 20
 - path: indicators.stoch_rsi_smooth1
+  gate:
+    path: filters.use_stoch_rsi_filter
+    eq: 1
   values:
-  - 2.0
-  - 3.0
-  - 4.0
-  - 5.0
+  - 2
+  - 3
+  - 4
+  - 5
 - path: indicators.stoch_rsi_smooth2
+  gate:
+    path: filters.use_stoch_rsi_filter
+    eq: 1
   values:
-  - 2.0
-  - 3.0
-  - 4.0
-  - 5.0
+  - 2
+  - 3
+  - 4
+  - 5
 - path: indicators.stoch_rsi_window
+  gate:
+    path: filters.use_stoch_rsi_filter
+    eq: 1
   values:
-  - 10.0
-  - 12.0
-  - 14.0
-  - 16.0
-  - 18.0
-  - 20.0
+  - 10
+  - 12
+  - 14
+  - 16
+  - 18
+  - 20
 - path: indicators.vol_sma_window
   values:
-  - 10.0
-  - 15.0
-  - 20.0
-  - 25.0
-  - 30.0
+  - 10
+  - 15
+  - 20
+  - 25
+  - 30
 - path: indicators.vol_trend_window
   values:
-  - 3.0
-  - 4.0
-  - 5.0
-  - 6.0
-  - 7.0
-  - 8.0
-  - 9.0
-  - 10.0
+  - 3
+  - 5
+  - 7
+  - 10
 - path: market_regime.auto_reverse_breadth_high
+  gate:
+    path: market_regime.enable_auto_reverse
+    eq: 1
   values:
-  - 63.0
-  - 90.0
-  - 100.0
+  - 65
+  - 80
+  - 95
 - path: market_regime.auto_reverse_breadth_low
+  gate:
+    path: market_regime.enable_auto_reverse
+    eq: 1
   values:
-  - 7.0
-  - 10.0
-  - 13.0
+  - 5
+  - 10
+  - 15
 - path: market_regime.breadth_block_long_below
+  gate:
+    path: market_regime.enable_regime_filter
+    eq: 1
   values:
-  - 7.0
-  - 10.0
-  - 13.0
+  - 5
+  - 10
+  - 15
 - path: market_regime.breadth_block_short_above
+  gate:
+    path: market_regime.enable_regime_filter
+    eq: 1
   values:
-  - 63.0
-  - 90.0
-  - 100.0
+  - 65
+  - 80
+  - 95
 - path: market_regime.enable_auto_reverse
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: market_regime.enable_regime_filter
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: thresholds.anomaly.ema_fast_dev_pct_gt
+  gate:
+    path: filters.enable_anomaly_filter
+    eq: 1
   values:
   - 0.35
   - 0.5
   - 0.65
 - path: thresholds.anomaly.price_change_pct_gt
+  gate:
+    path: filters.enable_anomaly_filter
+    eq: 1
   values:
   - 0.07
   - 0.1
   - 0.13
 - path: thresholds.entry.ave_adx_mult
+  gate:
+    path: thresholds.entry.ave_enabled
+    eq: 1
   values:
-  - 0.875
+  - 0.8
+  - 1.0
   - 1.25
-  - 1.625
-- path: thresholds.entry.ave_atr_ratio_gt
-  values:
-  - 1.05
   - 1.5
-  - 1.95
-- path: thresholds.entry.ave_avg_atr_window
+- path: thresholds.entry.ave_atr_ratio_gt
+  gate:
+    path: thresholds.entry.ave_enabled
+    eq: 1
   values:
-  - 30.0
-  - 40.0
-  - 50.0
-  - 60.0
-  - 70.0
-  - 80.0
+  - 1.0
+  - 1.25
+  - 1.5
+  - 2.0
+- path: thresholds.entry.ave_avg_atr_window
+  gate:
+    path: thresholds.entry.ave_enabled
+    eq: 1
+  values:
+  - 30
+  - 40
+  - 50
+  - 60
+  - 70
+  - 80
 - path: thresholds.entry.ave_enabled
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: thresholds.entry.btc_adx_override
   values:
-  - 28.0
-  - 40.0
-  - 52.0
+  - 28
+  - 40
+  - 52
 - path: thresholds.entry.enable_pullback_entries
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: thresholds.entry.enable_slow_drift_entries
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: thresholds.entry.high_conf_volume_mult
+  gate:
+    path: filters.require_volume_confirmation
+    eq: 1
   values:
-  - 1.75
+  - 1.5
+  - 2.0
   - 2.5
-  - 3.25
+  - 3.0
 - path: thresholds.entry.macd_hist_entry_mode
   values:
-  - 0.0
-  - 1.0
-  - 2.0
+  - 0
+  - 1
+  - 2
 - path: thresholds.entry.max_dist_ema_fast
   values:
   - 0.02
@@ -269,173 +298,245 @@ axes:
   - 0.05
 - path: thresholds.entry.min_adx
   values:
-  - 10.0
-  - 15.0
-  - 20.0
-  - 25.0
+  - 10
+  - 15
+  - 20
+  - 25
 - path: thresholds.entry.pullback_confidence
+  gate:
+    path: thresholds.entry.enable_pullback_entries
+    eq: 1
   values:
-  - 0.0
-  - 1.0
-  - 2.0
+  - 0
+  - 1
+  - 2
 - path: thresholds.entry.pullback_min_adx
+  gate:
+    path: thresholds.entry.enable_pullback_entries
+    eq: 1
   values:
-  - 15.4
-  - 22.0
-  - 28.6
+  - 15
+  - 22
+  - 30
 - path: thresholds.entry.pullback_require_macd_sign
+  gate:
+    path: thresholds.entry.enable_pullback_entries
+    eq: 1
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: thresholds.entry.pullback_rsi_long_min
+  gate:
+    path: thresholds.entry.enable_pullback_entries
+    eq: 1
   values:
-  - 35.0
-  - 50.0
-  - 65.0
+  - 35
+  - 50
+  - 65
 - path: thresholds.entry.pullback_rsi_short_max
+  gate:
+    path: thresholds.entry.enable_pullback_entries
+    eq: 1
   values:
-  - 35.0
-  - 50.0
-  - 65.0
+  - 35
+  - 50
+  - 65
 - path: thresholds.entry.slow_drift_min_adx
+  gate:
+    path: thresholds.entry.enable_slow_drift_entries
+    eq: 1
   values:
-  - 7.0
-  - 10.0
-  - 13.0
+  - 7
+  - 10
+  - 13
 - path: thresholds.entry.slow_drift_min_slope_pct
+  gate:
+    path: thresholds.entry.enable_slow_drift_entries
+    eq: 1
   values:
-  - 0.00042
+  - 0.0004
   - 0.0006
-  - 0.00078
+  - 0.0008
 - path: thresholds.entry.slow_drift_require_macd_sign
+  gate:
+    path: thresholds.entry.enable_slow_drift_entries
+    eq: 1
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: thresholds.entry.slow_drift_rsi_long_min
+  gate:
+    path: thresholds.entry.enable_slow_drift_entries
+    eq: 1
   values:
-  - 35.0
-  - 50.0
-  - 65.0
+  - 35
+  - 50
+  - 65
 - path: thresholds.entry.slow_drift_rsi_short_max
+  gate:
+    path: thresholds.entry.enable_slow_drift_entries
+    eq: 1
   values:
-  - 35.0
-  - 50.0
-  - 65.0
+  - 35
+  - 50
+  - 65
 - path: thresholds.entry.slow_drift_slope_window
+  gate:
+    path: thresholds.entry.enable_slow_drift_entries
+    eq: 1
   values:
-  - 10.0
-  - 15.0
-  - 20.0
-  - 25.0
-  - 30.0
-  - 35.0
-  - 40.0
+  - 10
+  - 15
+  - 20
+  - 25
+  - 30
+  - 35
+  - 40
 - path: thresholds.ranging.adx_below
+  gate:
+    path: filters.enable_ranging_filter
+    eq: 1
   values:
-  - 14.7
-  - 21.0
-  - 27.3
+  - 15
+  - 21
+  - 28
 - path: thresholds.ranging.bb_width_ratio_below
+  gate:
+    path: filters.enable_ranging_filter
+    eq: 1
   values:
-  - 0.56
+  - 0.5
   - 0.8
-  - 1.04
+  - 1.1
 - path: thresholds.ranging.min_signals
+  gate:
+    path: filters.enable_ranging_filter
+    eq: 1
   values:
-  - 1.0
-  - 2.0
-  - 3.0
+  - 1
+  - 2
+  - 3
 - path: thresholds.ranging.rsi_high
+  gate:
+    path: filters.enable_ranging_filter
+    eq: 1
   values:
-  - 37.1
-  - 53.0
-  - 68.9
+  - 37
+  - 53
+  - 69
 - path: thresholds.ranging.rsi_low
+  gate:
+    path: filters.enable_ranging_filter
+    eq: 1
   values:
-  - 32.9
-  - 47.0
-  - 61.1
+  - 33
+  - 47
+  - 61
 - path: thresholds.stoch_rsi.block_long_if_k_gt
+  gate:
+    path: filters.use_stoch_rsi_filter
+    eq: 1
   values:
-  - 0.595
-  - 0.85
-  - 1.105
+  - 0.6
+  - 0.75
+  - 0.9
 - path: thresholds.stoch_rsi.block_short_if_k_lt
+  gate:
+    path: filters.use_stoch_rsi_filter
+    eq: 1
   values:
-  - 0.105
+  - 0.1
   - 0.15
-  - 0.195
+  - 0.2
 - path: thresholds.tp_and_momentum.adx_strong_gt
   values:
-  - 28.0
-  - 40.0
-  - 52.0
+  - 28
+  - 40
+  - 52
 - path: thresholds.tp_and_momentum.adx_weak_lt
   values:
-  - 21.0
-  - 30.0
-  - 39.0
+  - 21
+  - 30
+  - 39
 - path: thresholds.tp_and_momentum.rsi_long_strong
   values:
-  - 36.4
-  - 52.0
-  - 67.6
+  - 36
+  - 52
+  - 68
 - path: thresholds.tp_and_momentum.rsi_long_weak
   values:
-  - 39.2
-  - 56.0
-  - 72.8
+  - 39
+  - 56
+  - 73
 - path: thresholds.tp_and_momentum.rsi_short_strong
   values:
-  - 33.6
-  - 48.0
-  - 62.4
+  - 34
+  - 48
+  - 62
 - path: thresholds.tp_and_momentum.rsi_short_weak
   values:
-  - 30.8
-  - 44.0
-  - 57.2
+  - 31
+  - 44
+  - 57
 - path: thresholds.tp_and_momentum.tp_mult_strong
   values:
-  - 4.9
-  - 7.0
-  - 9.1
+  - 5
+  - 7
+  - 9
 - path: thresholds.tp_and_momentum.tp_mult_weak
   values:
-  - 2.1
-  - 3.0
-  - 3.9
+  - 2
+  - 3
+  - 4
 - path: trade.add_cooldown_minutes
+  gate:
+    path: trade.enable_pyramiding
+    eq: 1
   values:
-  - 42.0
-  - 60.0
-  - 78.0
+  - 30
+  - 60
+  - 90
 - path: trade.add_fraction_of_base_margin
+  gate:
+    path: trade.enable_pyramiding
+    eq: 1
   values:
   - 0.25
   - 0.5
   - 0.75
   - 1.0
 - path: trade.add_min_confidence
+  gate:
+    path: trade.enable_pyramiding
+    eq: 1
   values:
-  - 0.0
-  - 1.0
-  - 2.0
+  - 0
+  - 1
+  - 2
 - path: trade.add_min_profit_atr
+  gate:
+    path: trade.enable_pyramiding
+    eq: 1
   values:
   - 0.35
   - 0.5
   - 0.65
 - path: trade.adx_sizing_full_adx
+  gate:
+    path: trade.enable_dynamic_sizing
+    eq: 1
   values:
-  - 28.0
-  - 40.0
-  - 52.0
+  - 28
+  - 40
+  - 52
 - path: trade.adx_sizing_min_mult
+  gate:
+    path: trade.enable_dynamic_sizing
+    eq: 1
   values:
-  - 0.42
+  - 0.4
   - 0.6
-  - 0.78
+  - 0.8
 - path: trade.allocation_pct
   values:
   - 0.05
@@ -446,344 +547,402 @@ axes:
   - 0.3
 - path: trade.block_exits_on_extreme_dev
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.breakeven_buffer_atr
+  gate:
+    path: trade.enable_breakeven_stop
+    eq: 1
   values:
   - 0.035
   - 0.05
   - 0.065
 - path: trade.breakeven_start_atr
+  gate:
+    path: trade.enable_breakeven_stop
+    eq: 1
   values:
   - 0.3
-  - 0.4
   - 0.5
-  - 0.6
   - 0.7
-  - 0.8
-  - 0.9
   - 1.0
 - path: trade.bump_to_min_notional
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.confidence_mult_high
+  gate:
+    path: trade.enable_dynamic_sizing
+    eq: 1
   values:
   - 0.7
   - 1.0
   - 1.3
 - path: trade.confidence_mult_low
+  gate:
+    path: trade.enable_dynamic_sizing
+    eq: 1
   values:
   - 0.35
   - 0.5
   - 0.65
 - path: trade.confidence_mult_medium
+  gate:
+    path: trade.enable_dynamic_sizing
+    eq: 1
   values:
   - 0.3
-  - 0.4
   - 0.5
-  - 0.6
   - 0.7
-  - 0.8
-  - 0.9
   - 1.0
 - path: trade.enable_breakeven_stop
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.enable_dynamic_leverage
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.enable_dynamic_sizing
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.enable_partial_tp
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.enable_pyramiding
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.enable_reef_filter
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.enable_rsi_overextension_exit
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.enable_ssf_filter
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.enable_vol_buffered_trailing
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.entry_cooldown_s
   values:
-  - 14.0
-  - 20.0
-  - 26.0
+  - 15
+  - 20
+  - 25
 - path: trade.entry_min_confidence
   values:
-  - 0.0
-  - 1.0
-  - 2.0
+  - 0
+  - 1
+  - 2
 - path: trade.exit_cooldown_s
   values:
-  - 10.0
-  - 15.0
-  - 20.0
+  - 10
+  - 15
+  - 20
 - path: trade.glitch_atr_mult
   values:
-  - 8.4
-  - 12.0
-  - 15.6
+  - 8
+  - 12
+  - 16
 - path: trade.glitch_price_dev_pct
   values:
-  - 0.28
+  - 0.25
   - 0.4
-  - 0.52
+  - 0.55
 - path: trade.leverage
+  gate:
+    path: trade.enable_dynamic_leverage
+    eq: 0
   values:
-  - 1.0
-  - 2.0
-  - 3.0
-  - 4.0
-  - 5.0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
 - path: trade.leverage_high
+  gate:
+    path: trade.enable_dynamic_leverage
+    eq: 1
   values:
-  - 3.5
-  - 5.0
-  - 6.5
+  - 3
+  - 5
+  - 7
 - path: trade.leverage_low
+  gate:
+    path: trade.enable_dynamic_leverage
+    eq: 1
   values:
-  - 0.7
-  - 1.0
-  - 1.3
-- path: trade.leverage_max_cap
-  values:
-  - 0.0
-  - 0.5
-  - 1.0
+  - 1
+  - 2
+  - 3
 - path: trade.leverage_medium
+  gate:
+    path: trade.enable_dynamic_leverage
+    eq: 1
   values:
-  - 2.0
-  - 3.0
-  - 4.0
-  - 5.0
+  - 2
+  - 3
+  - 4
+  - 5
 - path: trade.max_adds_per_symbol
+  gate:
+    path: trade.enable_pyramiding
+    eq: 1
   values:
-  - 0.0
-  - 1.0
-  - 2.0
-  - 3.0
+  - 0
+  - 1
+  - 2
+  - 3
 - path: trade.max_entry_orders_per_loop
   values:
-  - 4.0
-  - 6.0
-  - 8.0
+  - 4
+  - 6
+  - 8
 - path: trade.max_open_positions
   values:
-  - 14.0
-  - 20.0
-  - 26.0
+  - 14
+  - 20
+  - 26
 - path: trade.max_total_margin_pct
   values:
-  - 0.42
+  - 0.4
   - 0.6
-  - 0.78
+  - 0.8
 - path: trade.min_atr_pct
   values:
   - 0.0
-  - 0.001
   - 0.002
-  - 0.003
   - 0.004
-  - 0.005
 - path: trade.min_notional_usd
   values:
-  - 7.0
-  - 10.0
-  - 13.0
+  - 10
+  - 15
+  - 20
 - path: trade.reef_adx_threshold
+  gate:
+    path: trade.enable_reef_filter
+    eq: 1
   values:
-  - 31.5
-  - 45.0
-  - 58.5
+  - 30
+  - 45
+  - 60
 - path: trade.reef_long_rsi_block_gt
+  gate:
+    path: trade.enable_reef_filter
+    eq: 1
   values:
-  - 49.0
-  - 70.0
-  - 91.0
+  - 50
+  - 70
+  - 85
 - path: trade.reef_long_rsi_extreme_gt
+  gate:
+    path: trade.enable_reef_filter
+    eq: 1
   values:
-  - 52.5
-  - 75.0
-  - 97.5
+  - 60
+  - 75
+  - 85
 - path: trade.reef_short_rsi_block_lt
+  gate:
+    path: trade.enable_reef_filter
+    eq: 1
   values:
-  - 21.0
-  - 30.0
-  - 39.0
+  - 20
+  - 30
+  - 40
 - path: trade.reef_short_rsi_extreme_lt
+  gate:
+    path: trade.enable_reef_filter
+    eq: 1
   values:
-  - 17.5
-  - 25.0
-  - 32.5
+  - 15
+  - 25
+  - 35
 - path: trade.reentry_cooldown_max_mins
   values:
-  - 126.0
-  - 180.0
-  - 234.0
+  - 120
+  - 180
+  - 240
 - path: trade.reentry_cooldown_min_mins
   values:
-  - 30.0
-  - 45.0
-  - 60.0
-  - 75.0
-  - 90.0
+  - 30
+  - 45
+  - 60
+  - 75
+  - 90
 - path: trade.reentry_cooldown_minutes
   values:
-  - 42.0
-  - 60.0
-  - 78.0
+  - 30
+  - 60
+  - 90
 - path: trade.reverse_entry_signal
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.rsi_exit_lb_hi_profit
+  gate:
+    path: trade.enable_rsi_overextension_exit
+    eq: 1
   values:
-  - 21.0
-  - 30.0
-  - 39.0
+  - 21
+  - 30
+  - 39
 - path: trade.rsi_exit_lb_hi_profit_low_conf
+  gate:
+    path: trade.enable_rsi_overextension_exit
+    eq: 1
   values:
-  - 0.0
-  - 30.0
-  - 50.0
+  - 0
+  - 25
+  - 40
 - path: trade.rsi_exit_lb_lo_profit
+  gate:
+    path: trade.enable_rsi_overextension_exit
+    eq: 1
   values:
-  - 14.0
-  - 20.0
-  - 26.0
+  - 14
+  - 20
+  - 26
 - path: trade.rsi_exit_lb_lo_profit_low_conf
+  gate:
+    path: trade.enable_rsi_overextension_exit
+    eq: 1
   values:
-  - 0.0
-  - 30.0
-  - 50.0
+  - 0
+  - 15
+  - 30
 - path: trade.rsi_exit_profit_atr_switch
+  gate:
+    path: trade.enable_rsi_overextension_exit
+    eq: 1
   values:
-  - 1.05
+  - 1.0
   - 1.5
-  - 1.95
+  - 2.0
 - path: trade.rsi_exit_ub_hi_profit
+  gate:
+    path: trade.enable_rsi_overextension_exit
+    eq: 1
   values:
-  - 49.0
-  - 70.0
-  - 91.0
+  - 50
+  - 70
+  - 90
 - path: trade.rsi_exit_ub_hi_profit_low_conf
+  gate:
+    path: trade.enable_rsi_overextension_exit
+    eq: 1
   values:
-  - 0.0
-  - 30.0
-  - 50.0
+  - 0
+  - 60
+  - 75
 - path: trade.rsi_exit_ub_lo_profit
+  gate:
+    path: trade.enable_rsi_overextension_exit
+    eq: 1
   values:
-  - 56.0
-  - 80.0
-  - 100.0
+  - 60
+  - 80
+  - 100
 - path: trade.rsi_exit_ub_lo_profit_low_conf
+  gate:
+    path: trade.enable_rsi_overextension_exit
+    eq: 1
   values:
-  - 0.0
-  - 30.0
-  - 50.0
+  - 0
+  - 70
+  - 85
 - path: trade.sl_atr_mult
   values:
   - 1.0
-  - 1.25
   - 1.5
-  - 1.75
   - 2.0
-  - 2.25
   - 2.5
-  - 2.75
   - 3.0
 - path: trade.slippage_bps
   values:
-  - 7.0
-  - 10.0
-  - 13.0
+  - 5
+  - 10
+  - 15
 - path: trade.smart_exit_adx_exhaustion_lt
   values:
-  - 0.0
-  - 15.0
-  - 30.0
+  - 0
+  - 15
+  - 30
 - path: trade.smart_exit_adx_exhaustion_lt_low_conf
   values:
-  - 0.0
-  - 15.0
-  - 30.0
+  - 0
+  - 15
+  - 30
 - path: trade.tp_atr_mult
   values:
-  - 3.0
-  - 3.5
-  - 4.0
-  - 4.5
-  - 5.0
-  - 5.5
-  - 6.0
-  - 6.5
-  - 7.0
-  - 7.5
-  - 8.0
+  - 3
+  - 4
+  - 5
+  - 6
+  - 7
+  - 8
 - path: trade.tp_partial_atr_mult
+  gate:
+    path: trade.enable_partial_tp
+    eq: 1
   values:
   - 0.0
-  - 1.0
-  - 2.0
+  - 1.5
   - 3.0
-  - 4.0
 - path: trade.tp_partial_min_notional_usd
+  gate:
+    path: trade.enable_partial_tp
+    eq: 1
   values:
-  - 7.0
-  - 10.0
-  - 13.0
+  - 10
+  - 15
+  - 20
 - path: trade.tp_partial_pct
+  gate:
+    path: trade.enable_partial_tp
+    eq: 1
   values:
   - 0.35
   - 0.5
   - 0.65
 - path: trade.trailing_distance_atr
+  gate:
+    path: trade.enable_vol_buffered_trailing
+    eq: 1
   values:
   - 0.3
-  - 0.4
   - 0.5
-  - 0.6
   - 0.7
-  - 0.8
   - 0.9
-  - 1.0
-  - 1.1
   - 1.2
 - path: trade.trailing_distance_atr_low_conf
+  gate:
+    path: trade.enable_vol_buffered_trailing
+    eq: 1
   values:
   - 0.0
   - 0.5
   - 1.0
 - path: trade.trailing_start_atr
+  gate:
+    path: trade.enable_vol_buffered_trailing
+    eq: 1
   values:
   - 0.5
-  - 0.75
   - 1.0
-  - 1.25
   - 1.5
-  - 1.75
   - 2.0
 - path: trade.trailing_start_atr_low_conf
+  gate:
+    path: trade.enable_vol_buffered_trailing
+    eq: 1
   values:
   - 0.0
   - 0.5
@@ -795,19 +954,28 @@ axes:
   - 1.3
 - path: trade.tsme_require_adx_slope_negative
   values:
-  - 0.0
-  - 1.0
+  - 0
+  - 1
 - path: trade.vol_baseline_pct
+  gate:
+    path: trade.enable_dynamic_sizing
+    eq: 1
   values:
   - 0.007
   - 0.01
   - 0.013
 - path: trade.vol_scalar_max
+  gate:
+    path: trade.enable_dynamic_sizing
+    eq: 1
   values:
   - 0.7
   - 1.0
   - 1.3
 - path: trade.vol_scalar_min
+  gate:
+    path: trade.enable_dynamic_sizing
+    eq: 1
   values:
   - 0.35
   - 0.5

--- a/backtester/sweeps/full_144v_17phase/manifest.yaml
+++ b/backtester/sweeps/full_144v_17phase/manifest.yaml
@@ -1,13 +1,13 @@
 source_spec: backtester/sweeps/full_144v.yaml
 reference_spec: backtester/sweeps/full_34axis.yaml
 phase_count: 17
-total_axes: 142
+total_axes: 141
 base_combo: 16416
 target_combo: 100000
-achieved_combo: 103518
-total_combo: 103518
+achieved_combo: 100602
+total_combo: 100602
 four_value_axes_total: 10
-three_value_axes_total: 103
+three_value_axes_total: 102
 two_value_axes_total: 29
 notes:
 - All sweepable full_144v axes are included once across the 17 phases.
@@ -264,10 +264,10 @@ phases:
   - trade.trailing_distance_atr_low_conf
 - id: p16_144v
   file: p16_144v.yaml
-  axis_count: 8
-  combo: 4374
+  axis_count: 7
+  combo: 1458
   two_value_axes: 1
-  three_value_axes: 7
+  three_value_axes: 6
   four_value_axes: 0
   paths:
   - market_regime.auto_reverse_breadth_high
@@ -275,7 +275,6 @@ phases:
   - thresholds.ranging.bb_width_ratio_below
   - trade.add_min_profit_atr
   - trade.bump_to_min_notional
-  - trade.leverage_max_cap
   - trade.rsi_exit_lb_hi_profit_low_conf
   - trade.trailing_start_atr
 - id: p17_144v

--- a/backtester/sweeps/full_144v_17phase/p16_144v.yaml
+++ b/backtester/sweeps/full_144v_17phase/p16_144v.yaml
@@ -26,13 +26,8 @@ axes:
   - 0.65
 - path: trade.bump_to_min_notional
   values:
-  - 0.0
-  - 1.0
-- path: trade.leverage_max_cap
-  values:
-  - 0.0
-  - 0.5
-  - 1.0
+  - 0
+  - 1
 - path: trade.rsi_exit_lb_hi_profit_low_conf
   values:
   - 0.0


### PR DESCRIPTION
## Summary
- **Gated sweep axes**: New `AxisGate` in Rust sweep engine — sub-parameters freeze when their parent enable flag is OFF, dramatically reducing combo count across 18 gate groups (73 gated axes)
- **Parameter cleanup**: 92 of 141 axes revised — float→int for windows/counts/enums, range cleanup (odd fractionals→clean values), StochRSI/RSI-exit bug fixes, dense axes narrowed (8-11pt→3-6pt)
- **generate_config.py validation**: force leverage_max_cap=0, clamp min_notional≥$10, leverage integer [1,10]
- **initial_balance**: 10K→10M to match kernel seed and avoid cash exhaustion

## Test plan
- [x] `cargo build --release` — success
- [x] `cargo test` — 250 passed, 2 pre-existing fails (warmup boundary tests, unrelated)
- [x] YAML validation: 141 axes, 73 gated, no suspicious float-for-int values
- [x] bt-gpu compilation fixed (gate: None added to all SweepAxis initializers)

Generated with [Claude Code](https://claude.com/claude-code)