### PR TITLE
fix: enforce non-overlapping cross-parameter sweep constraints

### DIFF
--- a/backtester/crates/bt-core/tests/decision_semantics_contract.rs
+++ b/backtester/crates/bt-core/tests/decision_semantics_contract.rs
@@ -45,8 +45,8 @@ fn permissive_cfg() -> StrategyConfig {
     cfg.filters.require_adx_rising = false;
     cfg.filters.require_macro_alignment = false;
 
-    cfg.indicators.ema_fast_window = 1;
-    cfg.indicators.ema_slow_window = 2;
+    cfg.indicators.ema_fast_window = 2;
+    cfg.indicators.ema_slow_window = 3;
     cfg.thresholds.entry.min_adx = -1.0;
     cfg.thresholds.entry.max_dist_ema_fast = 1.0;
     cfg.thresholds.entry.macd_hist_entry_mode = MacdMode::None;
@@ -162,7 +162,13 @@ fn warmup_bar_count_blocks_entry_until_lookback_boundary() {
 
     assert_eq!(opens.len(), 1);
     assert_eq!(opens[0].timestamp_ms, 60_000);
-    assert_eq!(opens[0].price, 101.0 * (1.0 + cfg.trade.slippage_bps / 10_000.0));
+    let expected_price = 101.0 * (1.0 + cfg.trade.slippage_bps / 10_000.0);
+    assert!(
+        (opens[0].price - expected_price).abs() < 1e-6,
+        "price {:.10} should be close to {:.10}",
+        opens[0].price,
+        expected_price,
+    );
 }
 
 #[test]

--- a/backtester/sweeps/full_144v.yaml
+++ b/backtester/sweeps/full_144v.yaml
@@ -28,7 +28,7 @@
 #                 (fully implemented in Rust+Python, has sweep match arm,
 #                 materially impacts trade behavior). Net: +1 −1 = 142 axes.
 initial_balance: 10000000
-lookback: 200
+lookback: 260
 axes:
 - path: filters.adx_rising_saturation
   gate:
@@ -112,7 +112,6 @@ axes:
   - 8
   - 12
   - 16
-  - 20
 - path: indicators.ema_macro_window
   values:
   - 140
@@ -120,9 +119,9 @@ axes:
   - 260
 - path: indicators.ema_slow_window
   values:
-  - 15
-  - 25
-  - 35
+  - 21
+  - 30
+  - 40
   - 50
 - path: indicators.rsi_window
   values:
@@ -330,17 +329,17 @@ axes:
     path: thresholds.entry.enable_pullback_entries
     eq: 1
   values:
-  - 35
+  - 30
+  - 40
   - 50
-  - 65
 - path: thresholds.entry.pullback_rsi_short_max
   gate:
     path: thresholds.entry.enable_pullback_entries
     eq: 1
   values:
-  - 35
-  - 50
+  - 55
   - 65
+  - 75
 - path: thresholds.entry.slow_drift_min_adx
   gate:
     path: thresholds.entry.enable_slow_drift_entries
@@ -369,17 +368,17 @@ axes:
     path: thresholds.entry.enable_slow_drift_entries
     eq: 1
   values:
-  - 35
+  - 30
+  - 40
   - 50
-  - 65
 - path: thresholds.entry.slow_drift_rsi_short_max
   gate:
     path: thresholds.entry.enable_slow_drift_entries
     eq: 1
   values:
-  - 35
-  - 50
+  - 55
   - 65
+  - 75
 - path: thresholds.entry.slow_drift_slope_window
   gate:
     path: thresholds.entry.enable_slow_drift_entries
@@ -421,17 +420,17 @@ axes:
     path: filters.enable_ranging_filter
     eq: 1
   values:
-  - 37
-  - 53
-  - 69
+  - 54
+  - 62
+  - 70
 - path: thresholds.ranging.rsi_low
   gate:
     path: filters.enable_ranging_filter
     eq: 1
   values:
-  - 33
-  - 47
-  - 61
+  - 30
+  - 38
+  - 46
 - path: thresholds.stoch_rsi.block_long_if_k_gt
   gate:
     path: filters.use_stoch_rsi_filter
@@ -554,9 +553,9 @@ axes:
     path: trade.enable_breakeven_stop
     eq: 1
   values:
-  - 0.035
   - 0.05
-  - 0.065
+  - 0.1
+  - 0.15
 - path: trade.breakeven_start_atr
   gate:
     path: trade.enable_breakeven_stop
@@ -575,26 +574,25 @@ axes:
     path: trade.enable_dynamic_sizing
     eq: 1
   values:
-  - 0.7
+  - 0.9
   - 1.0
-  - 1.3
+  - 1.2
 - path: trade.confidence_mult_low
   gate:
     path: trade.enable_dynamic_sizing
     eq: 1
   values:
-  - 0.35
-  - 0.5
-  - 0.65
+  - 0.2
+  - 0.3
+  - 0.4
 - path: trade.confidence_mult_medium
   gate:
     path: trade.enable_dynamic_sizing
     eq: 1
   values:
-  - 0.3
   - 0.5
-  - 0.7
-  - 1.0
+  - 0.65
+  - 0.8
 - path: trade.enable_breakeven_stop
   values:
   - 0
@@ -671,8 +669,8 @@ axes:
     path: trade.enable_dynamic_leverage
     eq: 1
   values:
-  - 3
   - 5
+  - 6
   - 7
 - path: trade.leverage_low
   gate:
@@ -681,22 +679,18 @@ axes:
   values:
   - 1
   - 2
-  - 3
 - path: trade.leverage_medium
   gate:
     path: trade.enable_dynamic_leverage
     eq: 1
   values:
-  - 2
   - 3
   - 4
-  - 5
 - path: trade.max_adds_per_symbol
   gate:
     path: trade.enable_pyramiding
     eq: 1
   values:
-  - 0
   - 1
   - 2
   - 3
@@ -738,33 +732,33 @@ axes:
     path: trade.enable_reef_filter
     eq: 1
   values:
-  - 50
-  - 70
-  - 85
+  - 55
+  - 65
+  - 75
 - path: trade.reef_long_rsi_extreme_gt
   gate:
     path: trade.enable_reef_filter
     eq: 1
   values:
-  - 60
-  - 75
+  - 80
   - 85
+  - 90
 - path: trade.reef_short_rsi_block_lt
   gate:
     path: trade.enable_reef_filter
     eq: 1
   values:
-  - 20
-  - 30
-  - 40
+  - 25
+  - 35
+  - 45
 - path: trade.reef_short_rsi_extreme_lt
   gate:
     path: trade.enable_reef_filter
     eq: 1
   values:
+  - 10
   - 15
-  - 25
-  - 35
+  - 20
 - path: trade.reentry_cooldown_max_mins
   values:
   - 120
@@ -772,11 +766,9 @@ axes:
   - 240
 - path: trade.reentry_cooldown_min_mins
   values:
-  - 30
-  - 45
+  - 20
+  - 40
   - 60
-  - 75
-  - 90
 - path: trade.reentry_cooldown_minutes
   values:
   - 30
@@ -791,9 +783,9 @@ axes:
     path: trade.enable_rsi_overextension_exit
     eq: 1
   values:
-  - 21
-  - 30
-  - 39
+  - 25
+  - 32
+  - 40
 - path: trade.rsi_exit_lb_hi_profit_low_conf
   gate:
     path: trade.enable_rsi_overextension_exit
@@ -801,23 +793,23 @@ axes:
   values:
   - 0
   - 25
-  - 40
+  - 38
 - path: trade.rsi_exit_lb_lo_profit
   gate:
     path: trade.enable_rsi_overextension_exit
     eq: 1
   values:
-  - 14
+  - 10
+  - 15
   - 20
-  - 26
 - path: trade.rsi_exit_lb_lo_profit_low_conf
   gate:
     path: trade.enable_rsi_overextension_exit
     eq: 1
   values:
   - 0
-  - 15
-  - 30
+  - 10
+  - 20
 - path: trade.rsi_exit_profit_atr_switch
   gate:
     path: trade.enable_rsi_overextension_exit
@@ -832,8 +824,8 @@ axes:
     eq: 1
   values:
   - 50
+  - 60
   - 70
-  - 90
 - path: trade.rsi_exit_ub_hi_profit_low_conf
   gate:
     path: trade.enable_rsi_overextension_exit
@@ -841,23 +833,23 @@ axes:
   values:
   - 0
   - 60
-  - 75
+  - 70
 - path: trade.rsi_exit_ub_lo_profit
   gate:
     path: trade.enable_rsi_overextension_exit
     eq: 1
   values:
-  - 60
-  - 80
-  - 100
+  - 75
+  - 85
+  - 95
 - path: trade.rsi_exit_ub_lo_profit_low_conf
   gate:
     path: trade.enable_rsi_overextension_exit
     eq: 1
   values:
   - 0
-  - 70
-  - 85
+  - 80
+  - 90
 - path: trade.sl_atr_mult
   values:
   - 1.0
@@ -893,9 +885,9 @@ axes:
     path: trade.enable_partial_tp
     eq: 1
   values:
-  - 0.0
+  - 1.0
   - 1.5
-  - 3.0
+  - 2.5
 - path: trade.tp_partial_min_notional_usd
   gate:
     path: trade.enable_partial_tp
@@ -917,27 +909,26 @@ axes:
     path: trade.enable_vol_buffered_trailing
     eq: 1
   values:
+  - 0.2
   - 0.3
   - 0.5
   - 0.7
-  - 0.9
-  - 1.2
 - path: trade.trailing_distance_atr_low_conf
   gate:
     path: trade.enable_vol_buffered_trailing
     eq: 1
   values:
   - 0.0
+  - 0.3
   - 0.5
-  - 1.0
 - path: trade.trailing_start_atr
   gate:
     path: trade.enable_vol_buffered_trailing
     eq: 1
   values:
-  - 0.5
-  - 1.0
-  - 1.5
+  - 0.8
+  - 1.2
+  - 1.6
   - 2.0
 - path: trade.trailing_start_atr_low_conf
   gate:
@@ -945,7 +936,7 @@ axes:
     eq: 1
   values:
   - 0.0
-  - 0.5
+  - 0.7
   - 1.0
 - path: trade.tsme_min_profit_atr
   values:


### PR DESCRIPTION
## Summary
- Enforce non-overlapping ranges for 17 cross-parameter constraint groups (leverage tiers, confidence_mult tiers, RSI exit UB/LB, reef block/extreme, trailing distance/start, PESC cooldown, ranging RSI, etc.)
- Increase lookback 200→260 to match max ema_macro_window
- Remove redundant sweep values (max_adds=0 with pyramiding on, tp_partial_atr_mult=0.0)
- Fix 2 pre-existing test failures in `decision_semantics_contract` (EMA window=1 bug + float precision)

## Test plan
- [x] All 17 cross-parameter constraints validated via Python script
- [x] All 73 gate annotations verified correct
- [x] `cargo build --release` passes
- [x] `cargo test -p bt-core --test decision_semantics_contract` — 3/3 pass (was 1/3)
- [x] YAML compatibility verified against Rust engine (141 axes, all match arms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)