### PR TITLE
Support Hyperliquid unified-account balance reads

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -23,6 +23,11 @@ cargo run -p aiq-runtime -- live manifest --project-dir "$PWD" --json
 cargo run -p aiq-runtime -- live daemon --project-dir "$PWD"
 ```
 
+When the Hyperliquid account runs in `unifiedAccount`, the Rust runtime and Hub
+now treat `spotClearinghouseState` as the source of truth for available trading
+balance and quote collateral. Perp `clearinghouseState` still supplies position
+rows, but its balance fields are not used for unified-account sizing.
+
 ## Assist
 
 Assist mode runs signal generation and exit tunnel computation without

--- a/hub/src/hyperliquid.rs
+++ b/hub/src/hyperliquid.rs
@@ -1,8 +1,10 @@
-use serde::Deserialize;
+use serde::{de::DeserializeOwned, Deserialize};
+use std::collections::HashMap;
 use std::time::Duration;
 
 const HL_INFO_URL: &str = "https://api.hyperliquid.xyz/info";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const USD_QUOTE_COINS: &[&str] = &["USDC", "USDH", "USDE", "USDT0"];
 
 #[derive(Debug, Clone)]
 pub struct HlAccountSnapshot {
@@ -23,32 +25,69 @@ pub struct HlPositionSnapshot {
     pub margin_used: f64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UserAbstractionMode {
+    StandardLike,
+    UnifiedAccount,
+    PortfolioMargin,
+}
+
+impl UserAbstractionMode {
+    fn from_raw(raw: &str) -> Self {
+        match raw.trim() {
+            "unifiedAccount" => Self::UnifiedAccount,
+            "portfolioMargin" => Self::PortfolioMargin,
+            _ => Self::StandardLike,
+        }
+    }
+
+    fn uses_spot_balance_source(self) -> bool {
+        matches!(self, Self::UnifiedAccount | Self::PortfolioMargin)
+    }
+}
+
 /// Raw HL clearinghouseState response (only fields we need).
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct ClearinghouseResponse {
     #[serde(rename = "marginSummary")]
     margin_summary: MarginSummary,
-    /// Top-level withdrawable (string numeric).
     #[serde(default)]
-    withdrawable: Option<String>,
+    withdrawable: Option<StringOrNumber>,
     #[serde(rename = "assetPositions", default)]
     asset_positions: Vec<ClearinghouseAssetPosition>,
 }
 
-#[derive(Deserialize)]
-struct MarginSummary {
-    #[serde(rename = "accountValue")]
-    account_value: String,
-    #[serde(rename = "totalMarginUsed")]
-    total_margin_used: String,
+#[derive(Debug, Deserialize)]
+struct SpotClearinghouseResponse {
+    #[serde(default)]
+    balances: Vec<SpotBalance>,
+    #[serde(rename = "tokenToAvailableAfterMaintenance", default)]
+    token_to_available_after_maintenance: Vec<(u32, StringOrNumber)>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
+struct SpotBalance {
+    coin: String,
+    token: u32,
+    hold: StringOrNumber,
+    total: StringOrNumber,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarginSummary {
+    #[serde(rename = "accountValue")]
+    account_value: StringOrNumber,
+    #[serde(rename = "totalMarginUsed")]
+    total_margin_used: StringOrNumber,
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum StringOrNumber {
     String(String),
     Number(f64),
     Integer(i64),
+    Unsigned(u64),
 }
 
 impl StringOrNumber {
@@ -57,16 +96,17 @@ impl StringOrNumber {
             Self::String(value) => value.parse().ok(),
             Self::Number(value) => Some(*value),
             Self::Integer(value) => Some(*value as f64),
+            Self::Unsigned(value) => Some(*value as f64),
         }
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct ClearinghouseAssetPosition {
     position: ClearinghousePosition,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct ClearinghousePosition {
     coin: String,
     #[serde(rename = "entryPx")]
@@ -77,12 +117,12 @@ struct ClearinghousePosition {
     szi: StringOrNumber,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct ClearinghouseLeverage {
     value: Option<StringOrNumber>,
 }
 
-/// Fetch account snapshot from Hyperliquid clearinghouse API.
+/// Fetch account snapshot from Hyperliquid while respecting unified-account balance semantics.
 ///
 /// Returns `None` on any error (network, parse, timeout) so callers can
 /// gracefully fall back to DB-based values.
@@ -90,11 +130,53 @@ pub async fn fetch_account_snapshot(
     client: &reqwest::Client,
     address: &str,
 ) -> Option<HlAccountSnapshot> {
-    let body = serde_json::json!({
-        "type": "clearinghouseState",
-        "user": address,
-    });
+    let abstraction = fetch_user_abstraction(client, address)
+        .await
+        .unwrap_or(UserAbstractionMode::StandardLike);
+    let perps = fetch_info(
+        client,
+        serde_json::json!({
+            "type": "clearinghouseState",
+            "user": address,
+        }),
+    )
+    .await?;
+    let positions = parse_positions(&perps)?;
 
+    if abstraction.uses_spot_balance_source() {
+        let spot = fetch_info(
+            client,
+            serde_json::json!({
+                "type": "spotClearinghouseState",
+                "user": address,
+            }),
+        )
+        .await?;
+        parse_unified_account_snapshot(&spot, &positions)
+    } else {
+        parse_perps_account_snapshot(&perps, positions)
+    }
+}
+
+async fn fetch_user_abstraction(
+    client: &reqwest::Client,
+    address: &str,
+) -> Option<UserAbstractionMode> {
+    let raw: String = fetch_info(
+        client,
+        serde_json::json!({
+            "type": "userAbstraction",
+            "user": address,
+        }),
+    )
+    .await?;
+    Some(UserAbstractionMode::from_raw(&raw))
+}
+
+async fn fetch_info<T: DeserializeOwned>(
+    client: &reqwest::Client,
+    body: serde_json::Value,
+) -> Option<T> {
     let resp = client
         .post(HL_INFO_URL)
         .timeout(REQUEST_TIMEOUT)
@@ -112,30 +194,97 @@ pub async fn fetch_account_snapshot(
         return None;
     }
 
-    let data: ClearinghouseResponse = resp
-        .json()
+    resp.json()
         .await
         .map_err(|e| {
             tracing::warn!("HL API response parse failed: {e}");
             e
         })
-        .ok()?;
-
-    parse_account_snapshot(data)
+        .ok()
 }
 
-fn parse_account_snapshot(data: ClearinghouseResponse) -> Option<HlAccountSnapshot> {
-    let account_value: f64 = data.margin_summary.account_value.parse().ok()?;
-    let total_margin_used: f64 = data.margin_summary.total_margin_used.parse().ok()?;
-    let withdrawable: f64 = data
+fn parse_perps_account_snapshot(
+    data: &ClearinghouseResponse,
+    positions: Vec<HlPositionSnapshot>,
+) -> Option<HlAccountSnapshot> {
+    let account_value = data.margin_summary.account_value.as_f64()?;
+    let total_margin_used = data.margin_summary.total_margin_used.as_f64()?;
+    let withdrawable = data
         .withdrawable
-        .as_deref()
-        .and_then(|s| s.parse().ok())
+        .as_ref()
+        .and_then(StringOrNumber::as_f64)
         .unwrap_or(account_value - total_margin_used);
 
-    let positions = data
-        .asset_positions
-        .into_iter()
+    Some(HlAccountSnapshot {
+        account_value,
+        withdrawable,
+        total_margin_used,
+        positions,
+    })
+}
+
+fn parse_unified_account_snapshot(
+    data: &SpotClearinghouseResponse,
+    positions: &[HlPositionSnapshot],
+) -> Option<HlAccountSnapshot> {
+    let available_by_token = data
+        .token_to_available_after_maintenance
+        .iter()
+        .map(|(token, value)| value.as_f64().map(|value| (*token, value)))
+        .collect::<Option<HashMap<_, _>>>()?;
+
+    let mut account_value = 0.0;
+    let mut withdrawable = 0.0;
+    let mut saw_usdc = false;
+
+    for balance in data
+        .balances
+        .iter()
+        .filter(|balance| balance.coin.eq_ignore_ascii_case("USDC"))
+    {
+        saw_usdc = true;
+        let total = balance.total.as_f64()?;
+        let hold = balance.hold.as_f64()?;
+        account_value += total;
+        withdrawable += available_by_token
+            .get(&balance.token)
+            .copied()
+            .unwrap_or((total - hold).max(0.0));
+    }
+
+    if !saw_usdc {
+        for balance in data.balances.iter().filter(|balance| {
+            USD_QUOTE_COINS
+                .iter()
+                .any(|coin| balance.coin.eq_ignore_ascii_case(coin))
+        }) {
+            let total = balance.total.as_f64()?;
+            let hold = balance.hold.as_f64()?;
+            account_value += total;
+            withdrawable += available_by_token
+                .get(&balance.token)
+                .copied()
+                .unwrap_or((total - hold).max(0.0));
+        }
+    }
+
+    let hold_back = (account_value - withdrawable).max(0.0);
+    let perps_margin_used = positions
+        .iter()
+        .map(|position| position.margin_used.max(0.0))
+        .sum::<f64>();
+
+    Some(HlAccountSnapshot {
+        account_value,
+        withdrawable,
+        total_margin_used: hold_back.max(perps_margin_used),
+        positions: positions.to_vec(),
+    })
+}
+
+fn parse_positions(data: &ClearinghouseResponse) -> Option<Vec<HlPositionSnapshot>> {
+    data.asset_positions
+        .iter()
         .filter_map(|asset| {
             let symbol = asset.position.coin.trim().to_ascii_uppercase();
             if symbol.is_empty() {
@@ -151,7 +300,7 @@ fn parse_account_snapshot(data: ClearinghouseResponse) -> Option<HlAccountSnapsh
                 .as_ref()
                 .and_then(StringOrNumber::as_f64)
                 .unwrap_or(0.0);
-            let leverage: f64 = asset
+            let leverage = asset
                 .position
                 .leverage
                 .as_ref()
@@ -179,14 +328,8 @@ fn parse_account_snapshot(data: ClearinghouseResponse) -> Option<HlAccountSnapsh
                 margin_used,
             })
         })
-        .collect();
-
-    Some(HlAccountSnapshot {
-        account_value,
-        withdrawable,
-        total_margin_used,
-        positions,
-    })
+        .collect::<Vec<_>>()
+        .into()
 }
 
 #[cfg(test)]
@@ -194,7 +337,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_account_snapshot_extracts_positions() {
+    fn parse_perps_account_snapshot_extracts_positions() {
         let payload = serde_json::json!({
             "marginSummary": {
                 "accountValue": "222.032332",
@@ -223,14 +366,34 @@ mod tests {
             ]
         });
 
-        let parsed = parse_account_snapshot(serde_json::from_value(payload).unwrap()).unwrap();
-        assert_eq!(parsed.positions.len(), 2);
-        assert_eq!(parsed.positions[0].symbol, "HYPE");
-        assert_eq!(parsed.positions[0].pos_type, "SHORT");
-        assert!((parsed.positions[0].size - 8.31).abs() < 1e-9);
-        assert!((parsed.positions[0].margin_used - 77.627865).abs() < 1e-9);
-        assert_eq!(parsed.positions[1].symbol, "DOGE");
-        assert_eq!(parsed.positions[1].pos_type, "LONG");
-        assert!((parsed.positions[1].entry_price - 0.094602).abs() < 1e-9);
+        let parsed: ClearinghouseResponse = serde_json::from_value(payload).unwrap();
+        let positions = parse_positions(&parsed).unwrap();
+        let snapshot = parse_perps_account_snapshot(&parsed, positions.clone()).unwrap();
+        assert_eq!(positions.len(), 2);
+        assert_eq!(positions[0].symbol, "HYPE");
+        assert_eq!(positions[0].pos_type, "SHORT");
+        assert!((positions[0].size - 8.31).abs() < 1e-9);
+        assert!((positions[0].margin_used - 77.627865).abs() < 1e-9);
+        assert_eq!(positions[1].symbol, "DOGE");
+        assert_eq!(positions[1].pos_type, "LONG");
+        assert!((positions[1].entry_price - 0.094602).abs() < 1e-9);
+        assert!((snapshot.withdrawable - 42.1756).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_unified_account_snapshot_prefers_spot_balances() {
+        let spot: SpotClearinghouseResponse = serde_json::from_value(serde_json::json!({
+            "balances": [
+                { "coin": "USDC", "token": 0, "total": "208.63", "hold": "0.0" },
+                { "coin": "USDH", "token": 360, "total": "0.0", "hold": "0.0" }
+            ],
+            "tokenToAvailableAfterMaintenance": [[0, "208.63"]]
+        }))
+        .unwrap();
+
+        let snapshot = parse_unified_account_snapshot(&spot, &[]).unwrap();
+        assert!((snapshot.account_value - 208.63).abs() < 1e-9);
+        assert!((snapshot.withdrawable - 208.63).abs() < 1e-9);
+        assert_eq!(snapshot.total_margin_used, 0.0);
     }
 }

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -45,6 +45,11 @@ It also refreshes DB-backed exchange account and position snapshots so the Hub
 can fall back to current live balance and holdings when an in-memory
 Hyperliquid cache is unavailable or stale.
 
+For Hyperliquid `unifiedAccount` users, runtime balance reads now come from
+`spotClearinghouseState`, which Hyperliquid documents as the source of truth
+for trading balance across spot and perps. The runtime still reads perp
+`clearinghouseState` for open position rows.
+
 ## Ownership
 
 The runtime now owns:

--- a/runtime/aiq-runtime/src/live_hyperliquid.rs
+++ b/runtime/aiq-runtime/src/live_hyperliquid.rs
@@ -15,6 +15,7 @@ use crate::live_secrets::{validate_address, validate_secret_key, LiveSecrets};
 const DEFAULT_BASE_URL: &str = "https://api.hyperliquid.xyz";
 const DEFAULT_TIMEOUT_S: f64 = 4.0;
 const MAX_LEVERAGE: u32 = 50;
+const USD_QUOTE_COINS: &[&str] = &["USDC", "USDH", "USDE", "USDT0"];
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HyperliquidSignature {
@@ -80,6 +81,22 @@ struct ClearinghouseStateResponse {
 }
 
 #[derive(Debug, Deserialize)]
+struct SpotClearinghouseStateResponse {
+    #[serde(default)]
+    balances: Vec<SpotBalance>,
+    #[serde(rename = "tokenToAvailableAfterMaintenance", default)]
+    token_to_available_after_maintenance: Vec<(u32, StringOrNumber)>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpotBalance {
+    coin: String,
+    token: u32,
+    hold: StringOrNumber,
+    total: StringOrNumber,
+}
+
+#[derive(Debug, Deserialize)]
 struct MarginSummary {
     #[serde(rename = "accountValue")]
     account_value: StringOrNumber,
@@ -128,12 +145,34 @@ impl StringOrNumber {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UserAbstractionMode {
+    StandardLike,
+    UnifiedAccount,
+    PortfolioMargin,
+}
+
+impl UserAbstractionMode {
+    fn from_raw(raw: &str) -> Self {
+        match raw.trim() {
+            "unifiedAccount" => Self::UnifiedAccount,
+            "portfolioMargin" => Self::PortfolioMargin,
+            _ => Self::StandardLike,
+        }
+    }
+
+    fn uses_spot_balance_source(self) -> bool {
+        matches!(self, Self::UnifiedAccount | Self::PortfolioMargin)
+    }
+}
+
 pub struct HyperliquidClient {
     client: Client,
     base_url: Url,
     signing_key: SigningKey,
     pub main_address: String,
     asset_map: Mutex<Option<HashMap<String, HyperliquidAssetMeta>>>,
+    abstraction_mode: Mutex<Option<UserAbstractionMode>>,
 }
 
 impl HyperliquidClient {
@@ -169,37 +208,32 @@ impl HyperliquidClient {
             signing_key,
             main_address: secrets.main_address.trim().to_string(),
             asset_map: Mutex::new(None),
+            abstraction_mode: Mutex::new(None),
         })
     }
 
     pub fn account_snapshot(&self) -> Result<HyperliquidAccountSnapshot> {
-        let response: ClearinghouseStateResponse =
-            self.info("clearinghouseState", json!({ "user": self.main_address }))?;
-        let account_value_usd = response
-            .margin_summary
-            .account_value
-            .parse_f64("accountValue")?;
-        let total_margin_used_usd = response
-            .margin_summary
-            .total_margin_used
-            .parse_f64("totalMarginUsed")?;
-        let withdrawable_usd = response
-            .withdrawable
-            .as_ref()
-            .map(|value| value.parse_f64("withdrawable"))
-            .transpose()?
-            .unwrap_or(account_value_usd - total_margin_used_usd);
-        Ok(HyperliquidAccountSnapshot {
-            account_value_usd,
-            withdrawable_usd,
-            total_margin_used_usd,
-        })
+        let abstraction = self.user_abstraction()?;
+        if abstraction.uses_spot_balance_source() {
+            let spot_state: SpotClearinghouseStateResponse = self.info(
+                "spotClearinghouseState",
+                json!({ "user": self.main_address }),
+            )?;
+            let perps_state: ClearinghouseStateResponse =
+                self.info("clearinghouseState", json!({ "user": self.main_address }))?;
+            let positions = parse_positions(&perps_state)?;
+            parse_unified_account_snapshot(&spot_state, &positions)
+        } else {
+            parse_perps_account_snapshot(
+                &self.info("clearinghouseState", json!({ "user": self.main_address }))?,
+            )
+        }
     }
 
     pub fn positions(&self) -> Result<Vec<HyperliquidPosition>> {
         let response: ClearinghouseStateResponse =
             self.info("clearinghouseState", json!({ "user": self.main_address }))?;
-        parse_positions(response)
+        parse_positions(&response)
     }
 
     pub fn all_mids(&self) -> Result<HashMap<String, f64>> {
@@ -419,6 +453,26 @@ impl HyperliquidClient {
         self.post_action(action)
     }
 
+    fn user_abstraction(&self) -> Result<UserAbstractionMode> {
+        let cached = self
+            .abstraction_mode
+            .lock()
+            .map_err(|_| anyhow::anyhow!("abstraction mode mutex poisoned"))?;
+        if let Some(mode) = *cached {
+            return Ok(mode);
+        }
+        drop(cached);
+
+        let raw: String = self.info("userAbstraction", json!({ "user": self.main_address }))?;
+        let mode = UserAbstractionMode::from_raw(&raw);
+        let mut cached = self
+            .abstraction_mode
+            .lock()
+            .map_err(|_| anyhow::anyhow!("abstraction mode mutex poisoned"))?;
+        *cached = Some(mode);
+        Ok(mode)
+    }
+
     fn asset_for_symbol(&self, symbol: &str) -> Result<u32> {
         Ok(self.asset_meta(symbol)?.asset)
     }
@@ -528,6 +582,7 @@ pub struct HyperliquidInfoClient {
     client: Client,
     base_url: Url,
     pub main_address: String,
+    abstraction_mode: Mutex<Option<UserAbstractionMode>>,
 }
 
 impl HyperliquidInfoClient {
@@ -535,7 +590,11 @@ impl HyperliquidInfoClient {
         Self::with_base_url(main_address, DEFAULT_BASE_URL, timeout_s)
     }
 
-    pub fn with_base_url(main_address: &str, base_url: &str, timeout_s: Option<f64>) -> Result<Self> {
+    pub fn with_base_url(
+        main_address: &str,
+        base_url: &str,
+        timeout_s: Option<f64>,
+    ) -> Result<Self> {
         validate_address(main_address, "main_address")?;
         let base_url = Url::parse(base_url).context("invalid Hyperliquid base URL")?;
         let timeout_s = timeout_s.unwrap_or(DEFAULT_TIMEOUT_S).clamp(1.0, 30.0);
@@ -548,65 +607,71 @@ impl HyperliquidInfoClient {
             client,
             base_url,
             main_address: main_address.trim().to_string(),
+            abstraction_mode: Mutex::new(None),
         })
     }
 
     pub fn account_snapshot(&self) -> Result<HyperliquidAccountSnapshot> {
-        let response: ClearinghouseStateResponse =
-            self.info("clearinghouseState", json!({ "user": self.main_address }))?;
-        let account_value_usd = response
-            .margin_summary
-            .account_value
-            .parse_f64("accountValue")?;
-        let total_margin_used_usd = response
-            .margin_summary
-            .total_margin_used
-            .parse_f64("totalMarginUsed")?;
-        let withdrawable_usd = response
-            .withdrawable
-            .as_ref()
-            .map(|value| value.parse_f64("withdrawable"))
-            .transpose()?
-            .unwrap_or(account_value_usd - total_margin_used_usd);
-        Ok(HyperliquidAccountSnapshot {
-            account_value_usd,
-            withdrawable_usd,
-            total_margin_used_usd,
-        })
+        let abstraction = self.user_abstraction()?;
+        if abstraction.uses_spot_balance_source() {
+            let spot_state: SpotClearinghouseStateResponse = self.info(
+                "spotClearinghouseState",
+                json!({ "user": self.main_address }),
+            )?;
+            let perps_state: ClearinghouseStateResponse =
+                self.info("clearinghouseState", json!({ "user": self.main_address }))?;
+            let positions = parse_positions(&perps_state)?;
+            parse_unified_account_snapshot(&spot_state, &positions)
+        } else {
+            parse_perps_account_snapshot(
+                &self.info("clearinghouseState", json!({ "user": self.main_address }))?,
+            )
+        }
     }
 
     pub fn positions(&self) -> Result<Vec<HyperliquidPosition>> {
         let response: ClearinghouseStateResponse =
             self.info("clearinghouseState", json!({ "user": self.main_address }))?;
-        parse_positions(response)
+        parse_positions(&response)
     }
 
     pub fn account_and_positions(
         &self,
     ) -> Result<(HyperliquidAccountSnapshot, Vec<HyperliquidPosition>)> {
-        let response: ClearinghouseStateResponse =
+        let abstraction = self.user_abstraction()?;
+        let perps_state: ClearinghouseStateResponse =
             self.info("clearinghouseState", json!({ "user": self.main_address }))?;
-        let account_value_usd = response
-            .margin_summary
-            .account_value
-            .parse_f64("accountValue")?;
-        let total_margin_used_usd = response
-            .margin_summary
-            .total_margin_used
-            .parse_f64("totalMarginUsed")?;
-        let withdrawable_usd = response
-            .withdrawable
-            .as_ref()
-            .map(|value| value.parse_f64("withdrawable"))
-            .transpose()?
-            .unwrap_or(account_value_usd - total_margin_used_usd);
-        let snapshot = HyperliquidAccountSnapshot {
-            account_value_usd,
-            withdrawable_usd,
-            total_margin_used_usd,
+        let positions = parse_positions(&perps_state)?;
+        let snapshot = if abstraction.uses_spot_balance_source() {
+            let spot_state: SpotClearinghouseStateResponse = self.info(
+                "spotClearinghouseState",
+                json!({ "user": self.main_address }),
+            )?;
+            parse_unified_account_snapshot(&spot_state, &positions)?
+        } else {
+            parse_perps_account_snapshot(&perps_state)?
         };
-        let positions = parse_positions(response)?;
         Ok((snapshot, positions))
+    }
+
+    fn user_abstraction(&self) -> Result<UserAbstractionMode> {
+        let cached = self
+            .abstraction_mode
+            .lock()
+            .map_err(|_| anyhow::anyhow!("abstraction mode mutex poisoned"))?;
+        if let Some(mode) = *cached {
+            return Ok(mode);
+        }
+        drop(cached);
+
+        let raw: String = self.info("userAbstraction", json!({ "user": self.main_address }))?;
+        let mode = UserAbstractionMode::from_raw(&raw);
+        let mut cached = self
+            .abstraction_mode
+            .lock()
+            .map_err(|_| anyhow::anyhow!("abstraction mode mutex poisoned"))?;
+        *cached = Some(mode);
+        Ok(mode)
     }
 
     fn info<T: serde::de::DeserializeOwned>(
@@ -922,9 +987,94 @@ fn parse_json_response<T: serde::de::DeserializeOwned>(
         .with_context(|| format!("failed to parse {label} response"))
 }
 
-fn parse_positions(response: ClearinghouseStateResponse) -> Result<Vec<HyperliquidPosition>> {
+fn parse_perps_account_snapshot(
+    response: &ClearinghouseStateResponse,
+) -> Result<HyperliquidAccountSnapshot> {
+    let account_value_usd = response
+        .margin_summary
+        .account_value
+        .parse_f64("accountValue")?;
+    let total_margin_used_usd = response
+        .margin_summary
+        .total_margin_used
+        .parse_f64("totalMarginUsed")?;
+    let withdrawable_usd = response
+        .withdrawable
+        .as_ref()
+        .map(|value| value.parse_f64("withdrawable"))
+        .transpose()?
+        .unwrap_or(account_value_usd - total_margin_used_usd);
+    Ok(HyperliquidAccountSnapshot {
+        account_value_usd,
+        withdrawable_usd,
+        total_margin_used_usd,
+    })
+}
+
+fn parse_unified_account_snapshot(
+    spot_state: &SpotClearinghouseStateResponse,
+    positions: &[HyperliquidPosition],
+) -> Result<HyperliquidAccountSnapshot> {
+    let available_by_token = spot_state
+        .token_to_available_after_maintenance
+        .iter()
+        .map(|(token, value)| {
+            value
+                .parse_f64("tokenToAvailableAfterMaintenance")
+                .map(|value| (*token, value))
+        })
+        .collect::<Result<HashMap<_, _>>>()?;
+
+    let mut selected_balances = spot_state
+        .balances
+        .iter()
+        .filter(|balance| balance.coin.eq_ignore_ascii_case("USDC"));
+
+    let mut account_value_usd = 0.0;
+    let mut withdrawable_usd = 0.0;
+    let mut saw_usdc = false;
+    for balance in selected_balances.by_ref() {
+        saw_usdc = true;
+        let total = balance.total.parse_f64("total")?;
+        let hold = balance.hold.parse_f64("hold")?;
+        account_value_usd += total;
+        withdrawable_usd += available_by_token
+            .get(&balance.token)
+            .copied()
+            .unwrap_or((total - hold).max(0.0));
+    }
+
+    if !saw_usdc {
+        for balance in spot_state.balances.iter().filter(|balance| {
+            USD_QUOTE_COINS
+                .iter()
+                .any(|coin| balance.coin.eq_ignore_ascii_case(coin))
+        }) {
+            let total = balance.total.parse_f64("total")?;
+            let hold = balance.hold.parse_f64("hold")?;
+            account_value_usd += total;
+            withdrawable_usd += available_by_token
+                .get(&balance.token)
+                .copied()
+                .unwrap_or((total - hold).max(0.0));
+        }
+    }
+
+    let hold_back_usd = (account_value_usd - withdrawable_usd).max(0.0);
+    let perps_margin_used_usd = positions
+        .iter()
+        .map(|position| position.margin_used.max(0.0))
+        .sum::<f64>();
+    Ok(HyperliquidAccountSnapshot {
+        account_value_usd,
+        withdrawable_usd,
+        total_margin_used_usd: hold_back_usd.max(perps_margin_used_usd),
+    })
+}
+
+fn parse_positions(response: &ClearinghouseStateResponse) -> Result<Vec<HyperliquidPosition>> {
     let mut positions = Vec::new();
-    for asset in response.asset_positions {
+    for asset in &response.asset_positions {
         let symbol = asset.position.coin.trim().to_ascii_uppercase();
         if symbol.is_empty() {
             continue;
@@ -1221,7 +1371,7 @@ mod tests {
         });
 
         let response: ClearinghouseStateResponse = serde_json::from_value(payload).unwrap();
-        let positions = parse_positions(response).unwrap();
+        let positions = parse_positions(&response).unwrap();
         assert_eq!(positions.len(), 2);
         assert_eq!(positions[0].symbol, "HYPE");
         assert_eq!(positions[0].pos_type, "SHORT");
@@ -1229,6 +1379,33 @@ mod tests {
         assert!((positions[0].leverage - 4.0).abs() < 1e-9);
         assert!((positions[1].entry_price - 0.094602).abs() < 1e-9);
         assert!((positions[1].margin_used - 41.451039).abs() < 1e-9);
+    }
+
+    #[test]
+    fn unified_account_snapshot_uses_spot_quote_balance() {
+        let spot_state: SpotClearinghouseStateResponse = serde_json::from_value(json!({
+            "balances": [
+                {
+                    "coin": "USDC",
+                    "token": 0,
+                    "total": "208.63",
+                    "hold": "0.0"
+                },
+                {
+                    "coin": "USDH",
+                    "token": 360,
+                    "total": "0.0",
+                    "hold": "0.0"
+                }
+            ],
+            "tokenToAvailableAfterMaintenance": [[0, "208.63"]]
+        }))
+        .unwrap();
+
+        let snapshot = parse_unified_account_snapshot(&spot_state, &[]).unwrap();
+        assert!((snapshot.account_value_usd - 208.63).abs() < 1e-9);
+        assert!((snapshot.withdrawable_usd - 208.63).abs() < 1e-9);
+        assert_eq!(snapshot.total_margin_used_usd, 0.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- support Hyperliquid `unifiedAccount` and `portfolioMargin` balance reads by switching runtime and Hub balance snapshots to `spotClearinghouseState`
- keep perp `clearinghouseState` as the source for open position rows so manual trade and live execution continue to use the existing order and leverage paths
- document the unified-account balance contract in the runtime docs and runbook

## Verification
- `cargo test -p aiq-runtime live_hyperliquid`
- `cargo test --manifest-path hub/Cargo.toml hyperliquid`
- `cargo run -p aiq-runtime -- live sync-fills --project-dir /home/fol2hk/openclaw-plugins/ai_quant --secrets-path /home/fol2hk/.config/openclaw/ai-quant-secrets.json --lookback-hours 1 --dry-run --json`
  - observed `account_value_usd: 208.63` and `withdrawable_usd: 208.63` for the unified account

## Trading impact
- manual-trade sizing and preview paths still use the same signed Hyperliquid order and leverage actions; they now see the correct unified-account balance instead of `0`
- the live bot still uses the same execution actions; the change only fixes balance/collateral reads for risk sizing and state building