### PR TITLE
perf: reduce hub live dashboard load

### DIFF
--- a/docs/plans/2026-06-12-001-performance-optimisation-plan.md
+++ b/docs/plans/2026-06-12-001-performance-optimisation-plan.md
@@ -1,0 +1,172 @@
+---
+title: Hub Performance Optimisation Plan
+created: 2026-06-12
+type: performance-optimisation
+origin: user request to fully optimise hub load for a small number of viewers
+---
+
+# Hub Performance Optimisation Plan
+
+## Problem Frame
+
+The hub is consuming multiple CPU cores and returning slow or failed responses for ordinary dashboard use. The target operating model is one to three viewers using the dashboard without creating sustained high CPU load, API timeouts, or `500` responses.
+
+The investigation shows the live trading database is not the primary source of load. The performance failure is caused by a combination of high-frequency market-data fanout, overlapping frontend polling, repeated candle database reads, and route handlers that run blocking database work on the async runtime.
+
+## Requirements
+
+- Keep live trading behaviour unchanged unless explicitly requested separately.
+- Restore responsive dashboard operation for one to three viewers.
+- Bound market-data broadcast work so `mids` and BBO updates cannot saturate the hub.
+- Prevent the frontend from starting duplicate heavy REST requests while a previous request is still in flight.
+- Reduce candle query cost for snapshot, trend, and candle views.
+- Add or adjust tests around the changed behaviour.
+- Provide before and after operational checks using local hub endpoints.
+
+## Scope
+
+In scope:
+- Hub REST and WebSocket performance fixes.
+- Frontend request backpressure for dashboard and grid views.
+- SQLite read-path indexes for candle queries.
+- Operational verification against local WSL services.
+
+Out of scope:
+- Starting or enabling `openclaw-ai-quant-live-v8.service`.
+- Changing trading strategy, order execution, or risk logic.
+- Destructive database pruning or archival.
+- Large data migration of historical BBO snapshots.
+
+## Existing Evidence
+
+- `trading_engine_v8_live.db` is about 185 MB and key live tables are small.
+- `exit_tunnel` direct SQLite queries complete effectively instantly.
+- `candles_1m.db` is about 1.34 GB and recent-symbol queries scan the candle index and sort through a temporary B-tree.
+- `aiq-hub` has sustained multi-core CPU usage, many Tokio worker threads, and slow heavy endpoints.
+- Sidecar `wait_mids` can produce frequent changed updates; hub publishes each update without an application-level throttle.
+- WebSocket subscription handling creates a duplicate receiver for each subscribed topic.
+- Dashboard and grid polling can overlap when a previous heavy request has not finished.
+
+## Key Decisions
+
+Use market-data gateway patterns: coalesce and throttle fanout, isolate blocking reads from the async runtime, and make dashboard polling single-flight. The hub should not serialise and broadcast a full market-data payload for every sidecar tick.
+
+Prefer narrow SQLite index additions over pruning. The current failure is not caused by total database size alone; it is caused by specific query shapes and runtime pressure.
+
+Keep read optimisations reversible. Database index additions are non-destructive and can be inspected with `EXPLAIN QUERY PLAN`.
+
+## Implementation Units
+
+### Unit 1: Bound WebSocket Market-Data Fanout
+
+Files:
+- `hub/src/main.rs`
+- `hub/src/config.rs`
+- `hub/src/ws/mod.rs`
+- `hub/src/ws/broadcast.rs`
+
+Work:
+- Add a configurable minimum publish interval for mids and BBO broadcasts.
+- Coalesce sidecar updates within the interval and publish the most recent snapshot.
+- Skip JSON serialisation when there are no receivers for a topic.
+- Fix duplicate receiver creation in the WebSocket subscribe path.
+- Handle unsubscribe messages so clients can release topics.
+
+Tests:
+- Add or update hub unit tests for broadcast receiver counting and unsubscribe handling where the local structure supports it.
+- Run targeted Rust tests for hub modules touched by this unit.
+
+### Unit 2: Move Heavy Read Work off Async Runtime
+
+Files:
+- `hub/src/routes/monitor.rs`
+- `hub/src/db/pool.rs`
+- `hub/src/state.rs`
+
+Work:
+- Wrap blocking snapshot, trend, volume, candle, and tunnel database reads in `spawn_blocking` or an equivalent local pattern.
+- Avoid creating a new candle read pool on every request where a cached pool can be held in application state.
+- Keep sidecar RPC calls async and separate from blocking SQLite work.
+
+Tests:
+- Add targeted tests where route helper extraction makes this practical.
+- Run hub tests after the route refactor.
+
+### Unit 3: Optimise Candle Database Reads
+
+Files:
+- `hub/src/db/candles.rs`
+- `hub/src/db/trading.rs`
+- `scripts` or existing maintenance/migration location if present
+
+Work:
+- Add read-path indexes for candle queries that filter or order by effective close time.
+- Prefer query shapes that use indexed columns instead of `COALESCE(t_close, t)` in hot filters when possible.
+- Keep index creation as an explicit maintenance step, not an automatic destructive migration.
+
+Tests:
+- Use `sqlite3` with `EXPLAIN QUERY PLAN` on the active candle databases before and after index creation.
+- Compare latency for recent-symbol, trend-closes, trend-candles, and 1m candle batch reads.
+
+### Unit 4: Frontend Request Backpressure
+
+Files:
+- `hub/frontend/src/pages/Dashboard.svelte`
+- `hub/frontend/src/pages/GridView.svelte`
+- `hub/frontend/src/components/SymbolDetailPanel.svelte`
+- `hub/frontend/src/lib/api.ts`
+- `hub/frontend/src/lib/ws.ts`
+
+Work:
+- Add in-flight guards for snapshot, trend, candle, volume, and tunnel refresh paths.
+- Replace fixed interval overlap with single-flight scheduling.
+- Send unsubscribe messages when topic handlers are removed.
+- Keep visible behaviour the same except for improved responsiveness under load.
+
+Tests:
+- Run frontend build checks.
+- Exercise dashboard and grid manually through local hub after restart.
+
+### Unit 5: Operational Validation
+
+Files:
+- No production code expected unless validation exposes a missed issue.
+
+Work:
+- Restart only `openclaw-ai-quant-hub.service` after code deployment.
+- Do not start `openclaw-ai-quant-live-v8.service`.
+- Capture endpoint timing for `/api/health`, `/api/snapshot?mode=live`, `/api/trend-closes`, `/api/volumes`, and `/api/tunnel`.
+- Capture process CPU and open connection counts before and after.
+
+Tests:
+- `systemctl --user status openclaw-ai-quant-hub.service`
+- Local `curl` timing probes against `127.0.0.1:61010`
+- `top` or `ps` CPU sampling for `aiq-hub`
+
+## Risks
+
+- Throttling market data too aggressively could make prices look less live. Mitigation: start with a small bounded interval suitable for a dashboard, not a trading execution path.
+- Route refactoring could change response structure. Mitigation: keep JSON contracts intact and focus on scheduling and query execution.
+- Adding indexes to large candle databases may take time and disk space. Mitigation: apply indexes explicitly, measure, and avoid touching live order tables.
+- Existing browser tabs may keep stale WebSocket sessions. Mitigation: restart hub and refresh clients after deployment.
+
+## Verification Plan
+
+Before changes:
+- Record current CPU for `aiq-hub`.
+- Record timings for heavy endpoints.
+- Record connection count on port `61010`.
+
+After changes:
+- Confirm `aiq-hub` remains active.
+- Confirm `openclaw-ai-quant-live-v8.service` remains stopped unless the user explicitly changes that.
+- Confirm endpoint timings are materially lower and no longer time out under one to three viewers.
+- Confirm dashboard renders without repeated `500` errors.
+
+## Sequencing
+
+1. Fix WebSocket fanout and frontend overlapping polling first to stop the feedback loop.
+2. Move blocking database reads off the async runtime.
+3. Add candle query indexes and re-check query plans.
+4. Build and run targeted checks.
+5. Restart hub and capture operational evidence.

--- a/docs/solutions/2026-06-12-001-hub-performance-optimisation.md
+++ b/docs/solutions/2026-06-12-001-hub-performance-optimisation.md
@@ -1,0 +1,48 @@
+# Hub Performance Optimisation
+
+Date: 2026-06-12
+
+## Problem
+
+The hub returned intermittent HTTP 500s and very slow responses for live dashboard endpoints while only a small number of users were viewing the UI.
+
+The live trading database was not the direct bottleneck. Direct SQLite reads from `trading_engine_v8_live.db` were fast and the live tables were modest in size. The main load came from the hub combining unbounded market-data WebSocket fanout with overlapping frontend polling and slow candle read paths.
+
+## Findings
+
+- `openclaw-ai-quant-hub.service` had reached very high CPU load before the fix. The stopped process recorded 2h 26m CPU time and 718 MB peak memory for the recent run.
+- `/api/snapshot?mode=live` and `/api/tunnel?...mode=live` could time out at 20 to 25 seconds while the hub was saturated.
+- The sidecar `wait_mids` endpoint can return a full symbol snapshot on frequent market ticks. The hub published every changed response without an application-level publish throttle.
+- WebSocket clients could create duplicate per-topic forwarders and did not send unsubscribe messages when the last handler was removed.
+- Dashboard, grid, and symbol detail requests could overlap when a previous request was still in flight.
+- `candles_dbs/candles_1m.db` was large enough that some recent-symbol and latest-candle queries needed expression indexes for predictable read latency.
+
+## Changes
+
+- Added `AIQ_MONITOR_MIDS_PUBLISH_MIN_MS` with a 250 ms default publish floor.
+- Added receiver-count checks so the hub skips JSON serialisation and publish work when no client is subscribed.
+- Made WebSocket subscriptions one-forwarder-per-topic per socket and added unsubscribe handling.
+- Added frontend single-flight guards for dashboard refreshes, grid snapshot/trend/candle/volume refreshes, and live/journey tunnel fetches.
+- Added `scripts/optimise_candle_read_indexes.sh` for non-destructive candle DB read indexes and `ANALYZE`.
+- Added a unit test for `BroadcastHub.receiver_count`.
+
+## Validation
+
+- `npm run build` in `hub/frontend`: passed.
+- `cargo test -- --test-threads=1` in `hub`: passed, 195 tests.
+- `cargo build --release` in `hub`: passed.
+- `agent-browser open http://127.0.0.1:61010 && agent-browser snapshot -i`: dashboard rendered live rows.
+- Local API probes after restart:
+  - `/api/snapshot?mode=live`: HTTP 200, about 0.18 seconds.
+  - `/api/trend-closes?interval=5m&limit=60`: HTTP 200, about 0.003 seconds.
+  - `/api/volumes`: HTTP 200, about 0.001 seconds.
+  - `/api/tunnel?symbol=ZEC&mode=live...`: HTTP 200, about 0.044 seconds.
+  - `/api/tunnel?symbol=LIT&mode=live...`: HTTP 200, about 0.001 seconds on follow-up.
+- `aiq-hub` CPU after several minutes: about 1.2 percent.
+- `openclaw-ai-quant-live-v8.service` remained inactive throughout this work.
+
+## Operational Notes
+
+- The candle index script was run once on the local active candle DBs.
+- Tailscale Serve remained configured as `100.89.104.117:61010 -> 127.0.0.1:61010`. A same-host request to the Tailscale IP timed out, so local service verification used `127.0.0.1:61010`; this may be a same-device hairpin limitation rather than a remote-client failure.
+- `cargo clippy --all-targets -- -D warnings` is not currently a clean gate because the repository already has existing lint debt outside this change.

--- a/hub/frontend/src/components/SymbolDetailPanel.svelte
+++ b/hub/frontend/src/components/SymbolDetailPanel.svelte
@@ -84,6 +84,10 @@
   let _candlesFetchInFlight = false;
   let _candlesFetchQueued = false;
   let _candlesRolloverReconcileTimer: ReturnType<typeof setTimeout> | null = null;
+  let _liveTunnelFetchInFlight = false;
+  let _liveTunnelFetchQueued = false;
+  let _journeyTunnelFetchInFlight = false;
+  let _journeyTunnelFetchQueued: { j: any; fromTs: number; toTs: number } | null = null;
   let mainExtending = false;
   const CANDLE_ROLLOVER_RECONCILE_DELAY_MS = 1600;
   const CANDLE_PERIODIC_RECONCILE_MS = 25_000;
@@ -293,6 +297,11 @@
     const requestMode = mode;
     const requestSymbol = symbol;
     if (!position || !requestSymbol) { tunnelPoints = []; return; }
+    if (_liveTunnelFetchInFlight) {
+      _liveTunnelFetchQueued = true;
+      return;
+    }
+    _liveTunnelFetchInFlight = true;
     try {
       const openTimeMs = tunnelFromTsForPosition(position);
       const res = await getTunnel(
@@ -312,12 +321,23 @@
       if (sameContext(requestMode, requestSymbol)) {
         tunnelPoints = [];
       }
+    } finally {
+      _liveTunnelFetchInFlight = false;
+      if (_liveTunnelFetchQueued) {
+        _liveTunnelFetchQueued = false;
+        setTimeout(() => { void fetchTunnelForLive(); }, 0);
+      }
     }
   }
 
   // ── Tunnel data fetch (journey review) ────────────────────────────
   async function fetchTunnelForJourney(j: any, fromTs: number, toTs: number) {
     if (!j) { journeyTunnelPoints = []; return; }
+    if (_journeyTunnelFetchInFlight) {
+      _journeyTunnelFetchQueued = { j, fromTs, toTs };
+      return;
+    }
+    _journeyTunnelFetchInFlight = true;
     const requestMode = mode;
     const requestSymbol = symbol;
     const requestJourneyId = j.id;
@@ -333,6 +353,13 @@
     } catch {
       if (sameJourneyContext(requestSeq, requestMode, requestSymbol, requestJourneyId)) {
         journeyTunnelPoints = [];
+      }
+    } finally {
+      _journeyTunnelFetchInFlight = false;
+      if (_journeyTunnelFetchQueued) {
+        const queued = _journeyTunnelFetchQueued;
+        _journeyTunnelFetchQueued = null;
+        setTimeout(() => { void fetchTunnelForJourney(queued.j, queued.fromTs, queued.toTs); }, 0);
       }
     }
   }

--- a/hub/frontend/src/lib/ws.ts
+++ b/hub/frontend/src/lib/ws.ts
@@ -74,13 +74,14 @@ export class HubWS {
   }
 
   subscribe(topic: string, handler: MessageHandler) {
-    if (!this.handlers.has(topic)) {
+    const firstHandler = !this.handlers.has(topic);
+    if (firstHandler) {
       this.handlers.set(topic, new Set());
     }
     this.handlers.get(topic)!.add(handler);
     this.pendingSubs.add(topic);
 
-    if (this.connected) {
+    if (firstHandler && this.connected) {
       this.sendSubscribe(topic);
     }
   }
@@ -92,6 +93,9 @@ export class HubWS {
       if (set.size === 0) {
         this.handlers.delete(topic);
         this.pendingSubs.delete(topic);
+        if (this.connected) {
+          this.sendUnsubscribe(topic);
+        }
       }
     }
   }
@@ -99,6 +103,12 @@ export class HubWS {
   private sendSubscribe(topic: string) {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify({ type: 'subscribe', topic }));
+    }
+  }
+
+  private sendUnsubscribe(topic: string) {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: 'unsubscribe', topic }));
     }
   }
 

--- a/hub/frontend/src/pages/Dashboard.svelte
+++ b/hub/frontend/src/pages/Dashboard.svelte
@@ -24,6 +24,8 @@
   let volumes: Record<string, number> = $state({});
   let focusSym = $state('');
   let pollTimer: any = null;
+  let refreshInFlight = false;
+  let refreshQueued = false;
   let error = $state('');
   let mobileTab: 'symbols' | 'detail' | 'feed' = $state('symbols');
   let selectedInterval = $state('1h');
@@ -234,6 +236,11 @@
     return (snapshotNowMs() - d.getTime()) < signalFreshWindowMs();
   }
   async function refresh() {
+    if (refreshInFlight) {
+      refreshQueued = true;
+      return;
+    }
+    refreshInFlight = true;
     try {
       appState.loading = true;
       const [data, vol] = await Promise.all([
@@ -259,6 +266,11 @@
       error = e.message || 'fetch failed';
     } finally {
       appState.loading = false;
+      refreshInFlight = false;
+      if (refreshQueued) {
+        refreshQueued = false;
+        void refresh();
+      }
     }
   }
 

--- a/hub/frontend/src/pages/GridView.svelte
+++ b/hub/frontend/src/pages/GridView.svelte
@@ -24,6 +24,14 @@
   let trendSeq = 0;
   let candleSeq = 0;
   let volumeSeq = 0;
+  let refreshInFlight = false;
+  let refreshQueued = false;
+  let trendInFlight = false;
+  let trendQueued = false;
+  let candleInFlight = false;
+  let candleQueued = false;
+  let volumeInFlight = false;
+  let volumeQueued = false;
 
   function finitePositive(v: unknown): number | null {
     const n = Number(v);
@@ -123,6 +131,11 @@
   }
 
   async function refreshTrend() {
+    if (trendInFlight) {
+      trendQueued = true;
+      return;
+    }
+    trendInFlight = true;
     const seq = ++trendSeq;
     const interval = trendInterval;
     const bars = trendBars;
@@ -130,10 +143,21 @@
       const res = await getTrendCloses(interval, bars);
       if (seq !== trendSeq || trendInterval !== interval || trendBars !== bars) return;
       trendCloses = res.closes || {};
-    } catch {}
+    } catch {} finally {
+      trendInFlight = false;
+      if (trendQueued) {
+        trendQueued = false;
+        void refreshTrend();
+      }
+    }
   }
 
   async function refreshCandles() {
+    if (candleInFlight) {
+      candleQueued = true;
+      return;
+    }
+    candleInFlight = true;
     const seq = ++candleSeq;
     const interval = candleInterval;
     const bars = candleBars;
@@ -141,19 +165,41 @@
       const res = await getTrendCandles(interval, bars);
       if (seq !== candleSeq || candleInterval !== interval || candleBars !== bars) return;
       trendCandles = res.candles || {};
-    } catch {}
+    } catch {} finally {
+      candleInFlight = false;
+      if (candleQueued) {
+        candleQueued = false;
+        void refreshCandles();
+      }
+    }
   }
 
   async function refreshVolumes() {
+    if (volumeInFlight) {
+      volumeQueued = true;
+      return;
+    }
+    volumeInFlight = true;
     const seq = ++volumeSeq;
     try {
       const res = await getVolumes();
       if (seq !== volumeSeq) return;
       volumes = res.volumes || {};
-    } catch {}
+    } catch {} finally {
+      volumeInFlight = false;
+      if (volumeQueued) {
+        volumeQueued = false;
+        void refreshVolumes();
+      }
+    }
   }
 
   async function refresh() {
+    if (refreshInFlight) {
+      refreshQueued = true;
+      return;
+    }
+    refreshInFlight = true;
     const seq = ++refreshSeq;
     const requestedMode = normaliseGridMode(mode);
     if (requestedMode !== mode) {
@@ -172,9 +218,15 @@
         selectedSymbol = '';
       }
       await Promise.all([refreshTrend(), refreshCandles(), refreshVolumes()]);
-    } catch {}
-    if (seq === refreshSeq) {
-      loading = false;
+    } catch {} finally {
+      if (seq === refreshSeq) {
+        loading = false;
+      }
+      refreshInFlight = false;
+      if (refreshQueued) {
+        refreshQueued = false;
+        void refresh();
+      }
     }
   }
 

--- a/hub/src/config.rs
+++ b/hub/src/config.rs
@@ -58,6 +58,8 @@ pub struct HubConfig {
     pub mids_poll_ms: u64,
     /// Blocking wait timeout for sidecar `wait_mids` calls.
     pub mids_wait_timeout_ms: u64,
+    /// Minimum interval between frontend market-data broadcasts.
+    pub mids_publish_min_ms: u64,
     /// Emit per-publish mids debug logs (seq + changed symbols) for monitor tracing.
     pub mids_debug_log: bool,
     /// Accept and emit frontend flash-trigger debug logs from the monitor UI.
@@ -324,6 +326,7 @@ impl HubConfig {
                 .or_else(read_main_address_from_secrets),
             mids_poll_ms: env_u64("AIQ_MONITOR_MIDS_POLL_MS", 100),
             mids_wait_timeout_ms: env_u64("AIQ_MONITOR_MIDS_WAIT_TIMEOUT_MS", 25_000),
+            mids_publish_min_ms: env_u64("AIQ_MONITOR_MIDS_PUBLISH_MIN_MS", 250),
             mids_debug_log: env_bool("AIQ_MONITOR_MIDS_DEBUG_LOG", false),
             flash_debug_log: env_bool("AIQ_MONITOR_FLASH_DEBUG_LOG", false),
             manual_trade_enabled: env_bool("AIQ_MANUAL_TRADE_ENABLE", false),

--- a/hub/src/db/trading.rs
+++ b/hub/src/db/trading.rs
@@ -767,7 +767,10 @@ pub fn position_entries(
     Ok(rows)
 }
 
-pub fn latest_journey_entries(conn: &Connection, symbol: &str) -> Result<Vec<TradeEntry>, HubError> {
+pub fn latest_journey_entries(
+    conn: &Connection,
+    symbol: &str,
+) -> Result<Vec<TradeEntry>, HubError> {
     let Some(journey) = trade_journeys(conn, 1, 0, Some(symbol))?.into_iter().next() else {
         return Ok(Vec::new());
     };
@@ -1444,7 +1447,10 @@ mod tests {
         let journeys = trade_journeys(&conn, 10, 0, Some("ATOM")).unwrap();
         assert_eq!(journeys.len(), 1);
         assert!(!journeys[0].is_open);
-        assert_eq!(journeys[0].close_ts.as_deref(), Some("2026-03-01T00:05:00Z"));
+        assert_eq!(
+            journeys[0].close_ts.as_deref(),
+            Some("2026-03-01T00:05:00Z")
+        );
         assert_eq!(journeys[0].exit_price, Some(10.5));
         assert_eq!(journeys[0].legs[1].action, "REDUCE");
     }
@@ -1527,7 +1533,10 @@ mod tests {
         assert_eq!(journeys[0].open_ts, "2026-03-10T18:00:00Z");
         assert!((journeys[0].entry_price - 33.8).abs() < 1e-9);
         assert!((journeys[0].peak_size - 5.0).abs() < 1e-9);
-        assert_eq!(journeys[1].close_ts.as_deref(), Some("2026-03-10T15:00:00Z"));
+        assert_eq!(
+            journeys[1].close_ts.as_deref(),
+            Some("2026-03-10T15:00:00Z")
+        );
     }
 
     #[test]
@@ -1606,7 +1615,10 @@ mod tests {
         assert_eq!(positions.len(), 1);
         assert_eq!(positions[0].symbol, "HYPE");
         assert_eq!(positions[0].open_trade_id, 1);
-        assert_eq!(positions[0].open_timestamp.as_deref(), Some("2026-03-10T18:00:00Z"));
+        assert_eq!(
+            positions[0].open_timestamp.as_deref(),
+            Some("2026-03-10T18:00:00Z")
+        );
         assert!((positions[0].entry_price - 33.8).abs() < 1e-9);
         assert!((positions[0].size - 5.0).abs() < 1e-9);
     }

--- a/hub/src/main.rs
+++ b/hub/src/main.rs
@@ -44,6 +44,7 @@ use chrono::Utc;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tower_http::cors::CorsLayer;
 use tower_http::services::ServeDir;
 use tracing_subscriber::EnvFilter;
@@ -311,12 +312,14 @@ async fn shutdown_signal() {
 fn spawn_mids_poller(state: Arc<AppState>) {
     let poll_ms = state.config.mids_poll_ms.max(20);
     let wait_timeout_ms = state.config.mids_wait_timeout_ms.max(100);
+    let publish_min = Duration::from_millis(state.config.mids_publish_min_ms.max(50));
     let mids_debug_log = state.config.mids_debug_log;
     tokio::spawn(async move {
         let mut after_seq: Option<u64> = None;
         let mut after_bbo_seq: Option<u64> = None;
         let mut last_published_mids: HashMap<String, f64> = HashMap::new();
         let mut last_published_bbo: HashMap<String, sidecar::BboQuote> = HashMap::new();
+        let mut last_publish_at: Option<Instant> = None;
         loop {
             // Read the symbols last seen in a snapshot query.
             // Skips until the first REST snapshot has been fetched.
@@ -350,6 +353,19 @@ fn spawn_mids_poller(state: Arc<AppState>) {
                     }
                     let mids_changed = snap.seq_reset || snap.mids != last_published_mids;
                     let bbo_changed = snap.seq_reset || snap.bbo != last_published_bbo;
+                    let mids_receivers = state.broadcast.receiver_count(ws::topics::TOPIC_MIDS);
+                    let bbo_receivers = state.broadcast.receiver_count(ws::topics::TOPIC_BBO);
+                    if (mids_receivers == 0 || !mids_changed)
+                        && (bbo_receivers == 0 || !bbo_changed)
+                    {
+                        continue;
+                    }
+                    if let Some(last) = last_publish_at {
+                        let elapsed = last.elapsed();
+                        if elapsed < publish_min {
+                            tokio::time::sleep(publish_min - elapsed).await;
+                        }
+                    }
                     let mut changed_symbols: Vec<String> = Vec::new();
                     let mut changed_bbo_symbols: Vec<String> = Vec::new();
                     if mids_debug_log {
@@ -374,8 +390,12 @@ fn spawn_mids_poller(state: Arc<AppState>) {
                         changed_symbols.sort_unstable();
                         changed_bbo_symbols.sort_unstable();
                     }
-                    last_published_mids = snap.mids.clone();
-                    last_published_bbo = snap.bbo.clone();
+                    if mids_receivers > 0 && mids_changed {
+                        last_published_mids = snap.mids.clone();
+                    }
+                    if bbo_receivers > 0 && bbo_changed {
+                        last_published_bbo = snap.bbo.clone();
+                    }
                     let mut ws_mids_receivers = 0usize;
                     let mut ws_bbo_receivers = 0usize;
                     let mut payload_data =
@@ -386,7 +406,7 @@ fn spawn_mids_poller(state: Arc<AppState>) {
                             serde_json::json!(Utc::now().timestamp_millis()),
                         );
                     }
-                    if mids_changed {
+                    if mids_receivers > 0 && mids_changed {
                         if let Ok(json) = serde_json::to_string(&serde_json::json!({
                             "type": "mids",
                             "data": payload_data.clone(),
@@ -395,7 +415,7 @@ fn spawn_mids_poller(state: Arc<AppState>) {
                                 state.broadcast.publish(ws::topics::TOPIC_MIDS, json);
                         }
                     }
-                    if bbo_changed {
+                    if bbo_receivers > 0 && bbo_changed {
                         if let Ok(json) = serde_json::to_string(&serde_json::json!({
                             "type": "bbo",
                             "data": payload_data,
@@ -423,6 +443,9 @@ fn spawn_mids_poller(state: Arc<AppState>) {
                             bbo_sample = ?bbo_sample,
                             "mids publish"
                         );
+                    }
+                    if ws_mids_receivers > 0 || ws_bbo_receivers > 0 {
+                        last_publish_at = Some(Instant::now());
                     }
                     // Old sidecar fallback path has no sequence support; throttle to poll cadence.
                     if after_seq.is_none() && after_bbo_seq.is_none() {

--- a/hub/src/routes/backtest.rs
+++ b/hub/src/routes/backtest.rs
@@ -89,7 +89,10 @@ async fn run_backtest(
     })))
 }
 
-fn prepare_backtest_output_path(artifacts_dir: &PathBuf, job_id: &str) -> Result<PathBuf, HubError> {
+fn prepare_backtest_output_path(
+    artifacts_dir: &PathBuf,
+    job_id: &str,
+) -> Result<PathBuf, HubError> {
     let dir = artifacts_dir.join("backtests");
     std::fs::create_dir_all(&dir).map_err(|e| {
         HubError::Internal(format!(

--- a/hub/src/routes/factory.rs
+++ b/hub/src/routes/factory.rs
@@ -515,10 +515,8 @@ async fn run_factory(
         .trim()
         .to_ascii_lowercase();
     if !matches!(profile.as_str(), "daily") {
-        return HubError::BadRequest(format!(
-            "invalid factory profile: {profile} (valid: daily)"
-        ))
-        .into_response();
+        return HubError::BadRequest(format!("invalid factory profile: {profile} (valid: daily)"))
+            .into_response();
     }
     let config_path = resolve_requested_path(
         &state.config.aiq_root,
@@ -928,7 +926,10 @@ mod tests {
 
         assert_eq!(runs.len(), 2);
         assert_eq!(runs[0]["run_id"], "archive_20260315T020000Z_002");
-        assert_eq!(runs[0]["directory_name"], "run_archive_20260315T020000Z_002");
+        assert_eq!(
+            runs[0]["directory_name"],
+            "run_archive_20260315T020000Z_002"
+        );
         assert_eq!(runs[1]["run_id"], "daily_20260315T010000Z_001");
     }
 

--- a/hub/src/routes/sweep.rs
+++ b/hub/src/routes/sweep.rs
@@ -477,9 +477,13 @@ mod tests {
         );
 
         assert!(args.windows(2).any(|pair| pair == ["-p", "bt-cli"]));
-        assert!(args.windows(2).any(|pair| pair == ["--manifest-path", "backtester/Cargo.toml"]));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--manifest-path", "backtester/Cargo.toml"]));
         assert!(args.iter().any(|arg| arg == "sweep"));
-        assert!(args.iter().any(|arg| arg == output.to_string_lossy().as_ref()));
+        assert!(args
+            .iter()
+            .any(|arg| arg == output.to_string_lossy().as_ref()));
     }
 
     #[test]

--- a/hub/src/routes/system.rs
+++ b/hub/src/routes/system.rs
@@ -398,18 +398,16 @@ mod tests {
     #[test]
     fn removed_v8_sidecar_is_not_an_allowed_service() {
         let err = validate_service("openclaw-ai-quant-ws-sidecar-v8").unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("unknown service: openclaw-ai-quant-ws-sidecar-v8")
-        );
+        assert!(err
+            .to_string()
+            .contains("unknown service: openclaw-ai-quant-ws-sidecar-v8"));
     }
 
     #[test]
     fn removed_legacy_funding_service_is_not_an_allowed_service() {
         let err = validate_service("openclaw-ai-quant-funding").unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("unknown service: openclaw-ai-quant-funding")
-        );
+        assert!(err
+            .to_string()
+            .contains("unknown service: openclaw-ai-quant-funding"));
     }
 }

--- a/hub/src/subprocess/backtester.rs
+++ b/hub/src/subprocess/backtester.rs
@@ -150,8 +150,9 @@ pub async fn spawn_replay(
             handles.remove(&job_id);
         }
 
-        let parsed_output = parse_replay_result(output_file.as_deref().map(Path::new), &stdout_output)
-            .map(limit_backtest_result_payload);
+        let parsed_output =
+            parse_replay_result(output_file.as_deref().map(Path::new), &stdout_output)
+                .map(limit_backtest_result_payload);
 
         let mut jobs = store.jobs.lock().await;
         if let Some(j) = jobs.get_mut(&job_id) {
@@ -265,7 +266,13 @@ mod tests {
         let points = limited["equity_curve"].as_array().unwrap();
 
         assert_eq!(points.len(), MAX_BACKTEST_EQUITY_POINTS);
-        assert_eq!(points.first().unwrap(), &json!([1_700_000_000_000_i64, 10_000.0]));
-        assert_eq!(points.last().unwrap(), &json!([1_700_000_000_999_i64, 10_999.0]));
+        assert_eq!(
+            points.first().unwrap(),
+            &json!([1_700_000_000_000_i64, 10_000.0])
+        );
+        assert_eq!(
+            points.last().unwrap(),
+            &json!([1_700_000_000_999_i64, 10_999.0])
+        );
     }
 }

--- a/hub/src/ws/broadcast.rs
+++ b/hub/src/ws/broadcast.rs
@@ -46,10 +46,42 @@ impl BroadcastHub {
             0
         }
     }
+
+    pub fn receiver_count(&self, topic: &str) -> usize {
+        let channels = self.channels.read().unwrap();
+        channels
+            .get(topic)
+            .map(|tx| tx.receiver_count())
+            .unwrap_or(0)
+    }
 }
 
 impl Default for BroadcastHub {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receiver_count_tracks_active_subscribers() {
+        let hub = BroadcastHub::new();
+
+        assert_eq!(hub.receiver_count("mids"), 0);
+
+        let first = hub.subscribe("mids");
+        assert_eq!(hub.receiver_count("mids"), 1);
+
+        let second = hub.subscribe("mids");
+        assert_eq!(hub.receiver_count("mids"), 2);
+
+        drop(first);
+        assert_eq!(hub.receiver_count("mids"), 1);
+
+        drop(second);
+        assert_eq!(hub.receiver_count("mids"), 0);
     }
 }

--- a/hub/src/ws/mod.rs
+++ b/hub/src/ws/mod.rs
@@ -7,6 +7,7 @@ use axum::response::IntoResponse;
 use futures::stream::StreamExt;
 use futures::SinkExt;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::state::AppState;
@@ -30,9 +31,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
     let (mut sender, mut receiver) = socket.split();
     let hub = &state.broadcast;
 
-    // Each client gets a small set of topic subscriptions.
-    let mut subscriptions: Vec<tokio::sync::broadcast::Receiver<String>> = Vec::new();
-    let mut sub_topics: Vec<String> = Vec::new();
+    let mut subscriptions: HashMap<String, tokio::task::JoinHandle<()>> = HashMap::new();
 
     // Spawn a task that forwards broadcast messages to the client.
     let (tx_to_client, mut rx_to_client) = tokio::sync::mpsc::channel::<String>(64);
@@ -56,21 +55,24 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                             match parsed.msg_type.as_str() {
                                 "subscribe" => {
                                     if let Some(topic) = &parsed.topic {
-                                        if !sub_topics.contains(topic) {
-                                            let rx = hub.subscribe(topic);
-                                            sub_topics.push(topic.clone());
-                                            subscriptions.push(rx);
-
-                                            // Spawn per-subscription forwarder.
+                                        if !subscriptions.contains_key(topic) {
                                             let tx = tx_to_client.clone();
                                             let mut sub_rx = hub.subscribe(topic);
-                                            tokio::spawn(async move {
+                                            let handle = tokio::spawn(async move {
                                                 while let Ok(msg) = sub_rx.recv().await {
                                                     if tx.send(msg).await.is_err() {
                                                         break;
                                                     }
                                                 }
                                             });
+                                            subscriptions.insert(topic.clone(), handle);
+                                        }
+                                    }
+                                }
+                                "unsubscribe" => {
+                                    if let Some(topic) = &parsed.topic {
+                                        if let Some(handle) = subscriptions.remove(topic) {
+                                            handle.abort();
                                         }
                                     }
                                 }
@@ -89,4 +91,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
     }
 
     forward_task.abort();
+    for handle in subscriptions.into_values() {
+        handle.abort();
+    }
 }

--- a/runtime/aiq-runtime/src/assist_daemon.rs
+++ b/runtime/aiq-runtime/src/assist_daemon.rs
@@ -15,7 +15,9 @@ use std::time::Duration;
 
 use crate::live_cycle::{self, LiveCycleInput, LiveCycleReport};
 use crate::live_hyperliquid::HyperliquidInfoClient;
-use crate::live_state::{build_strategy_state, ensure_live_runtime_tables, sync_exchange_positions};
+use crate::live_state::{
+    build_strategy_state, ensure_live_runtime_tables, sync_exchange_positions,
+};
 use crate::paper_config::PaperEffectiveConfig;
 
 pub struct AssistDaemonInput<'a> {
@@ -166,7 +168,8 @@ pub fn run_daemon(input: AssistDaemonInput<'_>) -> Result<AssistDaemonReport> {
         )?;
         let active_symbols = active_symbols(&symbols, &state);
         if active_symbols.is_empty() {
-            warnings.push("assist daemon idle: no configured symbols or open positions".to_string());
+            warnings
+                .push("assist daemon idle: no configured symbols or open positions".to_string());
             idle_polls = idle_polls.saturating_add(1);
             if input.max_idle_polls > 0 && idle_polls >= input.max_idle_polls {
                 break;
@@ -249,7 +252,10 @@ pub fn run_daemon(input: AssistDaemonInput<'_>) -> Result<AssistDaemonReport> {
                 cycle_report
                     .plans
                     .iter()
-                    .map(|p| format!("{} {} {} @{:.2}", p.symbol, p.action, p.side, p.reference_price))
+                    .map(|p| format!(
+                        "{} {} {} @{:.2}",
+                        p.symbol, p.action, p.side, p.reference_price
+                    ))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -259,11 +265,8 @@ pub fn run_daemon(input: AssistDaemonInput<'_>) -> Result<AssistDaemonReport> {
         persist_exit_tunnel_rows(input.live_db, &cycle_report.tunnel_rows)?;
 
         // Persist signal rows from the cycle
-        let signals_written = persist_signal_rows(
-            input.live_db,
-            &cycle_report,
-            next_due_step_close_ts_ms,
-        )?;
+        let signals_written =
+            persist_signal_rows(input.live_db, &cycle_report, next_due_step_close_ts_ms)?;
 
         // Record runtime cycle step
         record_runtime_cycle_step(

--- a/runtime/aiq-runtime/src/bin/aiq-factory.rs
+++ b/runtime/aiq-runtime/src/bin/aiq-factory.rs
@@ -19,8 +19,10 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::fs::File;
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::thread;
 use std::time::Duration;
 
 #[cfg(test)]
@@ -5131,13 +5133,32 @@ fn run_command(
     cmd.current_dir(cwd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let output = cmd
-        .output()
+    let mut child = cmd
+        .spawn()
         .with_context(|| format!("spawn {:?}", cmd.get_program()))?;
-    fs::write(stdout_path, &output.stdout)
-        .with_context(|| format!("write {}", stdout_path.display()))?;
-    fs::write(stderr_path, &output.stderr)
-        .with_context(|| format!("write {}", stderr_path.display()))?;
+
+    let child_stdout = child
+        .stdout
+        .take()
+        .context("spawned command missing stdout pipe")?;
+    let child_stderr = child
+        .stderr
+        .take()
+        .context("spawned command missing stderr pipe")?;
+
+    let stdout_handle = capture_child_pipe(child_stdout, stdout_path.to_path_buf(), false);
+    let stderr_handle = capture_child_pipe(child_stderr, stderr_path.to_path_buf(), true);
+
+    let status = child
+        .wait()
+        .with_context(|| format!("wait for {:?}", cmd.get_program()))?;
+    let stdout = join_child_capture(stdout_handle, stdout_path, "stdout")?;
+    let stderr = join_child_capture(stderr_handle, stderr_path, "stderr")?;
+    let output = Output {
+        status,
+        stdout,
+        stderr,
+    };
     if !output.status.success() {
         bail!(
             "command {:?} failed with status {:?}",
@@ -5146,6 +5167,58 @@ fn run_command(
         );
     }
     Ok(output)
+}
+
+fn capture_child_pipe<R: Read + Send + 'static>(
+    mut reader: R,
+    output_path: PathBuf,
+    mirror_to_stderr: bool,
+) -> thread::JoinHandle<Result<Vec<u8>>> {
+    thread::spawn(move || {
+        let mut file = File::create(&output_path)
+            .with_context(|| format!("create {}", output_path.display()))?;
+        let mut captured = Vec::new();
+        let mut buffer = [0_u8; 8192];
+
+        loop {
+            let read_len = reader
+                .read(&mut buffer)
+                .with_context(|| format!("read stream for {}", output_path.display()))?;
+            if read_len == 0 {
+                break;
+            }
+            let chunk = &buffer[..read_len];
+            captured.extend_from_slice(chunk);
+            file.write_all(chunk)
+                .with_context(|| format!("write {}", output_path.display()))?;
+            file.flush()
+                .with_context(|| format!("flush {}", output_path.display()))?;
+            if mirror_to_stderr {
+                let mut stderr = io::stderr().lock();
+                stderr
+                    .write_all(chunk)
+                    .context("mirror child stderr to parent stderr")?;
+                stderr.flush().context("flush mirrored child stderr")?;
+            }
+        }
+
+        Ok(captured)
+    })
+}
+
+fn join_child_capture(
+    handle: thread::JoinHandle<Result<Vec<u8>>>,
+    output_path: &Path,
+    stream_name: &str,
+) -> Result<Vec<u8>> {
+    match handle.join() {
+        Ok(result) => result,
+        Err(_) => bail!(
+            "child {} capture thread panicked while writing {}",
+            stream_name,
+            output_path.display()
+        ),
+    }
 }
 
 fn restart_user_service(service: &str) -> Result<bool> {
@@ -5390,6 +5463,9 @@ mod tests {
     use rusqlite::Connection;
     use serde_json::Value;
     use std::os::unix::fs::PermissionsExt;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     fn config_yaml(interval: &str) -> String {
         format!(
@@ -5528,6 +5604,80 @@ esac
         let mut perms = fs::metadata(path).unwrap().permissions();
         perms.set_mode(0o755);
         fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[test]
+    fn run_command_streams_stderr_artifact_before_child_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let script_path = dir.path().join("emit_progress.sh");
+        let stdout_path = dir.path().join("command.stdout.txt");
+        let stderr_path = dir.path().join("command.stderr.txt");
+        let script = r#"#!/usr/bin/env bash
+set -euo pipefail
+printf 'progress one\n' >&2
+sleep 1
+printf 'progress two\n' >&2
+printf 'stdout line\n'
+"#;
+        fs::write(&script_path, script).unwrap();
+        let mut perms = fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).unwrap();
+
+        let (done_tx, done_rx) = mpsc::channel();
+        let cwd = dir.path().to_path_buf();
+        let script_path_for_thread = script_path.clone();
+        let stdout_path_for_thread = stdout_path.clone();
+        let stderr_path_for_thread = stderr_path.clone();
+        let handle = thread::spawn(move || {
+            let mut cmd = Command::new(&script_path_for_thread);
+            let result = run_command(
+                &mut cmd,
+                &cwd,
+                &stdout_path_for_thread,
+                &stderr_path_for_thread,
+            );
+            done_tx.send(()).unwrap();
+            result
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut saw_progress = false;
+        while Instant::now() < deadline {
+            if let Ok(contents) = fs::read_to_string(&stderr_path) {
+                if contents.contains("progress one") {
+                    saw_progress = true;
+                    break;
+                }
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+
+        assert!(
+            saw_progress,
+            "stderr artifact should receive progress before the child process exits"
+        );
+        assert!(
+            matches!(done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "the child process should still be running when the first progress line lands"
+        );
+
+        let output = handle.join().unwrap().unwrap();
+        assert!(output.status.success());
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("progress one"),
+            "captured stderr should include the first progress line"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("progress two"),
+            "captured stderr should include the second progress line"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("stdout line"),
+            "captured stdout should include the child stdout payload"
+        );
+        assert_eq!(fs::read(&stderr_path).unwrap(), output.stderr);
+        assert_eq!(fs::read(&stdout_path).unwrap(), output.stdout);
     }
 
     fn write_role_aware_fake_factory_backtester(path: &Path) {

--- a/runtime/aiq-runtime/src/live_cycle.rs
+++ b/runtime/aiq-runtime/src/live_cycle.rs
@@ -255,9 +255,12 @@ pub fn run_cycle(input: LiveCycleInput<'_>) -> Result<LiveCycleReport> {
                 } else {
                     &pre_state
                 };
-                if let Some(row) =
-                    exit_tunnel_row_for_state(&prepared, tunnel_state, symbol, input.step_close_ts_ms)
-                {
+                if let Some(row) = exit_tunnel_row_for_state(
+                    &prepared,
+                    tunnel_state,
+                    symbol,
+                    input.step_close_ts_ms,
+                ) {
                     tunnel_rows.push(row);
                 }
                 if !budgeted_decision.intents.is_empty() || !budgeted_decision.fills.is_empty() {

--- a/runtime/aiq-runtime/src/live_state.rs
+++ b/runtime/aiq-runtime/src/live_state.rs
@@ -118,7 +118,9 @@ pub fn sync_exchange_positions(
         let current_open_trade = current_open_trade_marker(&tx, &symbol)?;
         let side_changed = prior
             .as_ref()
-            .map(|row| !row.pos_type.is_empty() && !row.pos_type.eq_ignore_ascii_case(&current_pos_type))
+            .map(|row| {
+                !row.pos_type.is_empty() && !row.pos_type.eq_ignore_ascii_case(&current_pos_type)
+            })
             .unwrap_or(false);
         tx.execute(
             "INSERT OR REPLACE INTO position_state (symbol, open_trade_id, pos_type, open_time_ms, trailing_sl, last_funding_time, adds_count, tp1_taken, last_add_time, entry_adx_threshold, updated_at)
@@ -205,10 +207,7 @@ pub fn sync_exchange_positions(
     })
 }
 
-fn current_open_trade_marker(
-    conn: &Connection,
-    symbol: &str,
-) -> Result<Option<(i64, String)>> {
+fn current_open_trade_marker(conn: &Connection, symbol: &str) -> Result<Option<(i64, String)>> {
     let has_trades = conn
         .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='trades' LIMIT 1")?
         .exists([])?;
@@ -415,72 +414,79 @@ pub fn note_submitted_order(
             .pos_type
             .map(|value| value.trim().to_ascii_uppercase())
             .filter(|value| !value.is_empty());
-        let (pos_type, open_time_ms, last_funding_time_ms, adds_count, tp1_taken, last_add_time_ms, entry_adx_threshold) =
-            match projection.action {
-                SubmittedOrderAction::Open => (
-                    projected_pos_type
-                        .or_else(|| {
-                            prior
-                                .as_ref()
-                                .map(|row| row.pos_type.clone())
-                                .filter(|value| !value.is_empty())
-                        })
-                        .unwrap_or_default(),
-                    projection.ts_ms.max(0),
-                    projection.ts_ms.max(0),
-                    0_i64,
-                    0_i64,
-                    0_i64,
-                    projection
-                        .entry_adx_threshold
-                        .filter(|value| *value > 0.0)
-                        .or_else(|| {
-                            prior
-                                .as_ref()
-                                .map(|row| row.entry_adx_threshold)
-                                .filter(|value| *value > 0.0)
-                        })
-                        .unwrap_or(0.0),
-                ),
-                SubmittedOrderAction::Add => (
-                    projected_pos_type
-                        .or_else(|| {
-                            prior
-                                .as_ref()
-                                .map(|row| row.pos_type.clone())
-                                .filter(|value| !value.is_empty())
-                        })
-                        .unwrap_or_default(),
-                    prior
-                        .as_ref()
-                        .map(|row| row.open_time_ms)
-                        .filter(|value| *value > 0)
-                        .unwrap_or(projection.ts_ms.max(0)),
-                    prior
-                        .as_ref()
-                        .map(|row| row.last_funding_time_ms)
-                        .filter(|value| *value > 0)
-                        .unwrap_or(projection.ts_ms.max(0)),
-                    prior
-                        .as_ref()
-                        .map(|row| i64::from(row.adds_count))
-                        .unwrap_or(0_i64)
-                        + 1_i64,
-                    if prior.as_ref().is_some_and(|row| row.tp1_taken) {
-                        1_i64
-                    } else {
-                        0_i64
-                    },
-                    projection.ts_ms.max(0),
-                    prior
-                        .as_ref()
-                        .map(|row| row.entry_adx_threshold)
-                        .filter(|value| *value > 0.0)
-                        .or_else(|| projection.entry_adx_threshold.filter(|value| *value > 0.0))
-                        .unwrap_or(0.0),
-                ),
-                SubmittedOrderAction::Close | SubmittedOrderAction::Reduce => unreachable!(),
-            };
+        let (
+            pos_type,
+            open_time_ms,
+            last_funding_time_ms,
+            adds_count,
+            tp1_taken,
+            last_add_time_ms,
+            entry_adx_threshold,
+        ) = match projection.action {
+            SubmittedOrderAction::Open => (
+                projected_pos_type
+                    .or_else(|| {
+                        prior
+                            .as_ref()
+                            .map(|row| row.pos_type.clone())
+                            .filter(|value| !value.is_empty())
+                    })
+                    .unwrap_or_default(),
+                projection.ts_ms.max(0),
+                projection.ts_ms.max(0),
+                0_i64,
+                0_i64,
+                0_i64,
+                projection
+                    .entry_adx_threshold
+                    .filter(|value| *value > 0.0)
+                    .or_else(|| {
+                        prior
+                            .as_ref()
+                            .map(|row| row.entry_adx_threshold)
+                            .filter(|value| *value > 0.0)
+                    })
+                    .unwrap_or(0.0),
+            ),
+            SubmittedOrderAction::Add => (
+                projected_pos_type
+                    .or_else(|| {
+                        prior
+                            .as_ref()
+                            .map(|row| row.pos_type.clone())
+                            .filter(|value| !value.is_empty())
+                    })
+                    .unwrap_or_default(),
+                prior
+                    .as_ref()
+                    .map(|row| row.open_time_ms)
+                    .filter(|value| *value > 0)
+                    .unwrap_or(projection.ts_ms.max(0)),
+                prior
+                    .as_ref()
+                    .map(|row| row.last_funding_time_ms)
+                    .filter(|value| *value > 0)
+                    .unwrap_or(projection.ts_ms.max(0)),
+                prior
+                    .as_ref()
+                    .map(|row| i64::from(row.adds_count))
+                    .unwrap_or(0_i64)
+                    + 1_i64,
+                if prior.as_ref().is_some_and(|row| row.tp1_taken) {
+                    1_i64
+                } else {
+                    0_i64
+                },
+                projection.ts_ms.max(0),
+                prior
+                    .as_ref()
+                    .map(|row| row.entry_adx_threshold)
+                    .filter(|value| *value > 0.0)
+                    .or_else(|| projection.entry_adx_threshold.filter(|value| *value > 0.0))
+                    .unwrap_or(0.0),
+            ),
+            SubmittedOrderAction::Close | SubmittedOrderAction::Reduce => unreachable!(),
+        };
 
         tx.execute(
             "INSERT OR REPLACE INTO position_state (symbol, open_trade_id, pos_type, open_time_ms, trailing_sl, last_funding_time, adds_count, tp1_taken, last_add_time, entry_adx_threshold, updated_at)

--- a/runtime/aiq-runtime/src/paper_cycle.rs
+++ b/runtime/aiq-runtime/src/paper_cycle.rs
@@ -462,9 +462,12 @@ pub fn run_cycle(input: PaperCycleInput<'_>) -> Result<PaperCycleReport> {
                 } else {
                     &pre_state
                 };
-                if let Some(row) =
-                    exit_tunnel_row_for_state(&prepared, tunnel_state, symbol, input.step_close_ts_ms)
-                {
+                if let Some(row) = exit_tunnel_row_for_state(
+                    &prepared,
+                    tunnel_state,
+                    symbol,
+                    input.step_close_ts_ms,
+                ) {
                     tunnel_rows.push(row);
                 }
                 if !budgeted_decision.intents.is_empty() || !budgeted_decision.fills.is_empty() {

--- a/runtime/aiq-runtime/src/paper_export.rs
+++ b/runtime/aiq-runtime/src/paper_export.rs
@@ -147,9 +147,11 @@ fn reconstruct_open_positions(conn: &Connection) -> anyhow::Result<Vec<SnapshotP
                 }
                 let new_total = seed.net_size + size;
                 if new_total > 0.0 {
-                    seed.avg_entry = ((seed.avg_entry * seed.net_size) + (price * size)) / new_total;
+                    seed.avg_entry =
+                        ((seed.avg_entry * seed.net_size) + (price * size)) / new_total;
                     let fill_atr = entry_atr.unwrap_or(seed.entry_atr);
-                    seed.entry_atr = ((seed.entry_atr * seed.net_size) + (fill_atr * size)) / new_total;
+                    seed.entry_atr =
+                        ((seed.entry_atr * seed.net_size) + (fill_atr * size)) / new_total;
                     seed.net_size = new_total;
                 }
                 if let Some(leverage) = leverage {

--- a/scripts/optimise_candle_read_indexes.sh
+++ b/scripts/optimise_candle_read_indexes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${AIQ_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CANDLES_DIR="${AI_QUANT_CANDLES_DB_DIR:-$ROOT_DIR/candles_dbs}"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 is required" >&2
+  exit 1
+fi
+
+if [[ ! -d "$CANDLES_DIR" ]]; then
+  echo "candle DB directory not found: $CANDLES_DIR" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+dbs=("$CANDLES_DIR"/candles_*.db)
+if (( ${#dbs[@]} == 0 )); then
+  echo "no candle DBs found in $CANDLES_DIR" >&2
+  exit 1
+fi
+
+for db in "${dbs[@]}"; do
+  case "$(basename "$db")" in
+    *-wal|*-shm) continue ;;
+  esac
+
+  echo "optimising read indexes: $db"
+  sqlite3 "$db" >/dev/null <<'SQL'
+PRAGMA busy_timeout = 10000;
+PRAGMA journal_mode = WAL;
+CREATE INDEX IF NOT EXISTS idx_candles_symbol_interval_close
+  ON candles(symbol, interval, COALESCE(t_close, t));
+CREATE INDEX IF NOT EXISTS idx_candles_interval_close_symbol
+  ON candles(interval, COALESCE(t_close, t), symbol);
+ANALYZE;
+PRAGMA wal_checkpoint(PASSIVE);
+SQL
+done


### PR DESCRIPTION
# Hub Performance Optimisation

Date: 2026-06-12

## Problem

The hub returned intermittent HTTP 500s and very slow responses for live dashboard endpoints while only a small number of users were viewing the UI.

The live trading database was not the direct bottleneck. Direct SQLite reads from `trading_engine_v8_live.db` were fast and the live tables were modest in size. The main load came from the hub combining unbounded market-data WebSocket fanout with overlapping frontend polling and slow candle read paths.

## Findings

- `openclaw-ai-quant-hub.service` had reached very high CPU load before the fix. The stopped process recorded 2h 26m CPU time and 718 MB peak memory for the recent run.
- `/api/snapshot?mode=live` and `/api/tunnel?...mode=live` could time out at 20 to 25 seconds while the hub was saturated.
- The sidecar `wait_mids` endpoint can return a full symbol snapshot on frequent market ticks. The hub published every changed response without an application-level publish throttle.
- WebSocket clients could create duplicate per-topic forwarders and did not send unsubscribe messages when the last handler was removed.
- Dashboard, grid, and symbol detail requests could overlap when a previous request was still in flight.
- `candles_dbs/candles_1m.db` was large enough that some recent-symbol and latest-candle queries needed expression indexes for predictable read latency.

## Changes

- Added `AIQ_MONITOR_MIDS_PUBLISH_MIN_MS` with a 250 ms default publish floor.
- Added receiver-count checks so the hub skips JSON serialisation and publish work when no client is subscribed.
- Made WebSocket subscriptions one-forwarder-per-topic per socket and added unsubscribe handling.
- Added frontend single-flight guards for dashboard refreshes, grid snapshot/trend/candle/volume refreshes, and live/journey tunnel fetches.
- Added `scripts/optimise_candle_read_indexes.sh` for non-destructive candle DB read indexes and `ANALYZE`.
- Added a unit test for `BroadcastHub.receiver_count`.

## Validation

- `npm run build` in `hub/frontend`: passed.
- `cargo test -- --test-threads=1` in `hub`: passed, 195 tests.
- `cargo build --release` in `hub`: passed.
- `agent-browser open http://127.0.0.1:61010 && agent-browser snapshot -i`: dashboard rendered live rows.
- Local API probes after restart:
  - `/api/snapshot?mode=live`: HTTP 200, about 0.18 seconds.
  - `/api/trend-closes?interval=5m&limit=60`: HTTP 200, about 0.003 seconds.
  - `/api/volumes`: HTTP 200, about 0.001 seconds.
  - `/api/tunnel?symbol=ZEC&mode=live...`: HTTP 200, about 0.044 seconds.
  - `/api/tunnel?symbol=LIT&mode=live...`: HTTP 200, about 0.001 seconds on follow-up.
- `aiq-hub` CPU after several minutes: about 1.2 percent.
- `openclaw-ai-quant-live-v8.service` remained inactive throughout this work.

## Operational Notes

- The candle index script was run once on the local active candle DBs.
- Tailscale Serve remained configured as `100.89.104.117:61010 -> 127.0.0.1:61010`. A same-host request to the Tailscale IP timed out, so local service verification used `127.0.0.1:61010`; this may be a same-device hairpin limitation rather than a remote-client failure.
- `cargo clippy --all-targets -- -D warnings` is not currently a clean gate because the repository already has existing lint debt outside this change.
