### PR TITLE
fix: add standard mobile app meta tag

### DIFF
--- a/hub/frontend/index.html
+++ b/hub/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="theme-color" content="#0a0e14" />


### PR DESCRIPTION
Adds the standard mobile-web-app-capable meta tag alongside the existing Apple-specific tag so Chrome no longer reports the deprecated meta warning.\n\nValidation:\n- npm run build\n- Browser console/CDP reload check: no console logs, no network failures, mobile and Apple meta tags both present.